### PR TITLE
Expose more tab logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,14 @@
     "publish:major": "npm run build && node bin/index.js --publish=major",
     "start": "npm-run-all --parallel 'build:code -- --watch' 'build:docs -- -w -b'",
     "static-publish": "npm run build && static-publish --directory=docs --account=nrk-core --latest --major",
-    "test": "npm run lint && npm run build:code && jest"
+    "test:js": "jest",
+    "test": "npm run lint && npm run build:code && npm run test:jest"
   },
   "devDependencies": {
-    "jest": "^22.4.2",
+    "babel-core": "^6.26.3",
+    "babel-jest": "^22.4.3",
+    "babel-preset-env": "^1.6.1",
+    "jest": "^22.4.3",
     "npm-run-all": "^4.1.2",
     "rollup": "0.57.1",
     "rollup-plugin-buble": "0.19.2",
@@ -45,5 +49,15 @@
       "test",
       "expect"
     ]
+  },
+  "babel": {
+    "presets": [
+      "env"
+    ]
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.jsx?$": "babel-jest"
+    }
   }
 }

--- a/packages/core-tabs/core-tabs.js
+++ b/packages/core-tabs/core-tabs.js
@@ -1,24 +1,80 @@
 import {name, version} from './package.json'
 import {IS_ANDROID, addEvent, dispatchEvent, getUUID, queryAll} from '../utils'
 
+/**
+ * Options
+ *
+ * By setting dangerouslyPromiseToHandle**Panels** you promise:
+ *
+ * * setting tab[aria-controls] correctly
+ * * setting panel[id] correctly
+ * * using set**Panel**Attributes to update properties on the panel element
+ *
+ * By setting dangerouslyPromiseToHandle**Tabs** you promise:
+ *
+ * * setting tab[aria-controls] correctly
+ * * setting panel[id] correctly
+ * * using set**Tab**Attributes to update properties on the panel element
+ *
+ * @typedef {Object} Options
+ * @property {boolean} [dangerouslyPromiseToHandlePanels] I promise to handle panel attributes setTabAttributes.
+ * @property {boolean} [dangerouslyPromiseToHandleTabs] I promise to handle tab attributes by using setTabAttributes.
+ */
+
 const UUID = `data-${name}-${version}`.replace(/\W+/g, '-') // Strip invalid attribute characters
+const OPTIONS = `${UUID}-options`
 const ARIA = IS_ANDROID ? 'data' : 'aria' // Andriod has a bug and reads only label instead of content
 const KEYS = {SPACE: 32, END: 35, HOME: 36, LEFT: 37, UP: 38, RIGHT: 39, DOWN: 40}
 
-export default function tabs (tablists, open) { // open can be Number, String or Element
+/**
+ * Initialize core-tabs
+ *
+ * @param {String|NodeList|Element[]|Element} tablists A CSS selector string, nodeList, element array, or single element
+ * @param {Number|String|Element} open index, id or tab-element of the open tab
+ * @param {Options} [options]
+ */
+export default function coreTabs (tablists, open, options = {}) { // open can be Number, String or Element
   return queryAll(tablists).map((tablist) => {
     tablist.setAttribute(UUID, '')
+    tablist.setAttribute(OPTIONS, JSON.stringify(options))
     tablist.setAttribute('role', 'tablist')
-    setOpen(tablist, open)
+    setOpen(tablist, open, options)
     return tablist
   })
+}
+
+/**
+ * Updates a panel element with correct a11y attributes.
+ *
+ * @param {Element} panel the panel to update
+ * @param {Element} tab the tab this panel belongs to
+ * @param {boolean} selected tab is selected
+ */
+export function setPanelAttributes (panel, tab, selected) {
+  panel.setAttribute(`${ARIA}-labelledby`, tab.id)
+  panel.setAttribute('role', 'tabpanel')
+  panel.setAttribute('tabindex', 0)
+  panel[selected ? 'removeAttribute' : 'setAttribute']('hidden', '')
+}
+
+/**
+ * Updates a tab element with correct a11y attributes
+ *
+ * @param {Element} tab the tab to update
+ * @param {boolean} selected tab is selected
+ */
+export function setTabAttributes (tab, selected) {
+  tab.setAttribute('role', 'tab')
+  tab.setAttribute('tabindex', selected - 1)
+  tab.setAttribute('aria-selected', selected)
 }
 
 addEvent(UUID, 'click', (event) => {
   if (event.ctrlKey || event.altKey || event.metaKey) return
   for (let el = event.target; el; el = el.parentElement) {
     if (el.getAttribute('role') === 'tab' && el.parentElement.hasAttribute(UUID)) {
-      return setOpen(el.parentElement, el) || event.preventDefault() // Also prevent links
+      const tablist = el.parentElement
+      return setOpen(tablist, el, JSON.parse(tablist.getAttribute(OPTIONS))) || event.preventDefault() // Also prevent links
     }
   }
 })
@@ -45,31 +101,39 @@ addEvent(UUID, 'keydown', (event) => {
   }
 })
 
-function getOpenPanel (panels) {
-  return Math.max(0, panels.indexOf(panels.filter((pan) => !pan.hasAttribute('hidden'))[0]))
+function getOpenTabIndex (tabs) {
+  return Math.max(0, tabs.indexOf(tabs.filter(tab => tab.getAttribute('aria-selected') === true)))
 }
 
-function setOpen (tablist, open) { // open can be Number, String or Element
+/**
+ * @param {Element} tablist
+ * @param {Number|String|Element} open
+ * @param {Options} [options]
+ */
+function setOpen (tablist, open, options = {}) { // open can be Number, String or Element
   const next = tablist.nextElementSibling ? tablist.nextElementSibling.children : []
   const tabs = queryAll(tablist.children).filter((tab) => tab.nodeName === 'A' || tab.nodeName === 'BUTTON')
   const panels = tabs.map((tab, i) => document.getElementById(tab.getAttribute('aria-controls')) || next[i])
-  const isOpen = getOpenPanel(panels)
+  const isOpen = getOpenTabIndex(tabs)
   const willOpen = tabs.reduce((acc, tab, i) => (i === open || tab === open || tab.id === open) ? i : acc, isOpen)
   const isUpdate = isOpen === willOpen || dispatchEvent(tablist, 'tabs.toggle', {isOpen, willOpen, tabs, panels})
-  const nextOpen = isUpdate ? willOpen : getOpenPanel(panels) // dispatchEvent can change attributes, so check getOpenPanel again
+  const nextOpen = isUpdate ? willOpen : getOpenTabIndex(tabs) // dispatchEvent can change attributes, so check getOpenPanel again
 
   tabs.forEach((tab, index) => {
     const selected = index === nextOpen
     const panel = panels[index]
 
-    tab.setAttribute('role', 'tab')
-    tab.setAttribute('tabindex', selected - 1)
-    tab.setAttribute('aria-selected', selected)
-    tab.setAttribute('aria-controls', panel.id = panel.id || getUUID())
-    panel.setAttribute(`${ARIA}-labelledby`, tab.id = tab.id || getUUID())
-    panel.setAttribute('role', 'tabpanel')
-    panel.setAttribute('tabindex', 0)
-    panel[selected ? 'removeAttribute' : 'setAttribute']('hidden', '')
+    // Set correct ids, if they are not already defined
+    panel.id = panel.id || getUUID()
+    tab.id = tab.id || getUUID()
+    tab.setAttribute('aria-controls', panel.id)
+
+    if (!options.dangerouslyPromiseToHandleTabs) {
+      setTabAttributes(tab, selected)
+    }
+    if (!options.dangerouslyPromiseToHandlePanels) {
+      setPanelAttributes(panel, tab, selected)
+    }
   })
 
   return nextOpen

--- a/packages/core-tabs/core-tabs.js
+++ b/packages/core-tabs/core-tabs.js
@@ -50,7 +50,7 @@ function getOpenPanel (panels) {
 }
 
 function setOpen (tablist, open) { // open can be Number, String or Element
-  const next = tablist.nextElementSibling.children
+  const next = tablist.nextElementSibling ? tablist.nextElementSibling.children : []
   const tabs = queryAll(tablist.children).filter((tab) => tab.nodeName === 'A' || tab.nodeName === 'BUTTON')
   const panels = tabs.map((tab, i) => document.getElementById(tab.getAttribute('aria-controls')) || next[i])
   const isOpen = getOpenPanel(panels)

--- a/packages/core-tabs/core-tabs.test.js
+++ b/packages/core-tabs/core-tabs.test.js
@@ -1,0 +1,40 @@
+import coreTabs from './core-tabs'
+
+describe('core-tabs', () => {
+  it('can init on standard HTML', () => {
+    document.body.innerHTML = `
+      <div class="my-tabs">
+        <button>Button tab</button>
+      </div>
+      <!-- Next element children will become panels of correlating tab -->
+      <div>
+        <div id="my-panel">Text of tab 1</div>
+      </div>`
+
+    coreTabs('.my-tabs')
+
+    expect(document.getElementById('my-panel').hasAttribute('aria-labelledby')).toBeTruthy()
+  })
+  it('can init on html without panels as nextElementSibling. panels found by aria-controls', () => {
+    document.body.innerHTML = `
+    <div>
+      <div id="my-tabs">
+        <button aria-controls="my-panel">Button tab</button>
+      </div>
+    </div>
+    <!--
+      Putting tabs somewhere else in the DOM.
+
+      NB! there must not be any semantic content between tabs and panels.
+    -->
+    <div>
+      <div id="my-panel">Panel</div>
+    </div>`
+
+    const tabs = document.querySelector('#my-tabs')
+
+    coreTabs(tabs)
+
+    expect(document.getElementById('my-panel').hasAttribute('aria-labelledby')).toBeTruthy()
+  })
+})

--- a/packages/core-tabs/core-tabs.test.js
+++ b/packages/core-tabs/core-tabs.test.js
@@ -1,25 +1,102 @@
-import coreTabs from './core-tabs'
+import coreTabs, { setPanelAttributes, setTabAttributes } from './core-tabs'
+
+function expectActiveTab (tab, { controls }) {
+  expect(tab.getAttribute('aria-controls')).toEqual(controls)
+  expect(tab.getAttribute('aria-controls')).toBeTruthy()
+  expect(tab.getAttribute('role')).toEqual('tab')
+  expect(tab.getAttribute('tabindex')).toEqual('0')
+  expect(tab.getAttribute('aria-selected')).toEqual('true')
+}
+
+function expectInactiveTab (tab, { controls }) {
+  expect(tab.getAttribute('aria-controls')).toEqual(controls)
+  expect(tab.getAttribute('aria-controls')).toBeTruthy()
+  expect(tab.getAttribute('role')).toEqual('tab')
+  expect(tab.getAttribute('tabindex')).toEqual('-1')
+  expect(tab.getAttribute('aria-selected')).toEqual('false')
+}
+
+function expectActivePanel (panel, { labelledby }) {
+  expect(panel.getAttribute('aria-labelledby')).toEqual(labelledby)
+  expect(panel.getAttribute('aria-labelledby')).toBeTruthy()
+  expect(panel.getAttribute('role')).toEqual('tabpanel')
+  expect(panel.getAttribute('tabindex')).toEqual('0')
+  expect(panel.hasAttribute('hidden')).toBeFalsy()
+}
+
+function expectInactivePanel (panel, { labelledby }) {
+  expect(panel.getAttribute('aria-labelledby')).toEqual(labelledby)
+  expect(panel.getAttribute('aria-labelledby')).toBeTruthy()
+  expect(panel.getAttribute('role')).toEqual('tabpanel')
+  expect(panel.getAttribute('tabindex')).toEqual('0')
+  expect(panel.hasAttribute('hidden')).toBeTruthy()
+}
+const standardHTML = `
+<div class="my-tabs">
+  <button>Button tab 1</button>
+  <a>Button tab 2</a>
+</div>
+<!-- Next element children will become panels of correlating tab -->
+<div>
+  <article>Text of tab 1</article>
+  <section>Text of tab 2</section>
+</div>`
 
 describe('core-tabs', () => {
   it('can init on standard HTML', () => {
-    document.body.innerHTML = `
-      <div class="my-tabs">
-        <button>Button tab</button>
-      </div>
-      <!-- Next element children will become panels of correlating tab -->
-      <div>
-        <div id="my-panel">Text of tab 1</div>
-      </div>`
-
+    document.body.innerHTML = standardHTML
     coreTabs('.my-tabs')
 
-    expect(document.getElementById('my-panel').hasAttribute('aria-labelledby')).toBeTruthy()
+    const tablist = document.querySelector('.my-tabs')
+    const tab1 = document.querySelector('button')
+    const tab2 = document.querySelector('a')
+    const panel1 = document.querySelector('article')
+    const panel2 = document.querySelector('section')
+
+    expect(tablist.getAttribute('role')).toEqual('tablist')
+
+    expectActiveTab(tab1, { controls: panel1.id })
+    expectActivePanel(panel1, { labelledby: tab1.id })
+
+    expectInactiveTab(tab2, { controls: panel2.id })
+    expectInactivePanel(panel2, { labelledby: tab2.id })
+  })
+  it('can init with active tab index', () => {
+    document.body.innerHTML = standardHTML
+    coreTabs('.my-tabs', 1)
+
+    const tab1 = document.querySelector('button')
+    const tab2 = document.querySelector('a')
+    const panel1 = document.querySelector('article')
+    const panel2 = document.querySelector('section')
+
+    expectInactiveTab(tab1, { controls: panel1.id })
+    expectInactivePanel(panel1, { labelledby: tab1.id })
+    expectActiveTab(tab2, { controls: panel2.id })
+    expectActivePanel(panel2, { labelledby: tab2.id })
+  })
+  it('can init with active tab element', () => {
+    document.body.innerHTML = standardHTML
+
+    const tab1 = document.querySelector('button')
+    const tab2 = document.querySelector('a')
+
+    coreTabs('.my-tabs', tab2)
+
+    const panel1 = document.querySelector('article')
+    const panel2 = document.querySelector('section')
+
+    expectInactiveTab(tab1, { controls: panel1.id })
+    expectInactivePanel(panel1, { labelledby: tab1.id })
+    expectActiveTab(tab2, { controls: panel2.id })
+    expectActivePanel(panel2, { labelledby: tab2.id })
   })
   it('can init on html without panels as nextElementSibling. panels found by aria-controls', () => {
     document.body.innerHTML = `
     <div>
       <div id="my-tabs">
-        <button aria-controls="my-panel">Button tab</button>
+        <button aria-controls="panel-1">Button tab</button>
+        <button aria-controls="panel-2">Button tab</button>
       </div>
     </div>
     <!--
@@ -28,13 +105,124 @@ describe('core-tabs', () => {
       NB! there must not be any semantic content between tabs and panels.
     -->
     <div>
-      <div id="my-panel">Panel</div>
+      <div id="panel-1">Panel 1</div>
+      <div id="panel-2">Panel 2</div>
+    </div>`
+
+    coreTabs('#my-tabs', 0)
+
+    expectActivePanel(document.querySelector('#panel-1'), {
+      labelledby: document.querySelector('[aria-controls=panel-1]').id
+    })
+    expectInactivePanel(document.querySelector('#panel-2'), {
+      labelledby: document.querySelector('[aria-controls=panel-2]').id
+    })
+  })
+  it('coreTabs with dangerouslyPromiseToHandlePanels should not modify panels', () => {
+    document.body.innerHTML = `
+    <div>
+      <div id="my-tabs">
+        <button id="tab-1" aria-controls="my-panel-1">Button tab 1</button>
+        <button id="tab-2" aria-controls="my-panel-2">Button tab 2</button>
+      </div>
+    </div>
+    <!-- Next element children will become panels of correlating tab -->
+    <div id="my-panels">
+      <div id="my-panel-1">Text of tab 1</div>
+      <div id="my-panel-2">Text of tab 2</div>
     </div>`
 
     const tabs = document.querySelector('#my-tabs')
 
-    coreTabs(tabs)
+    const initialHTML = document.querySelector('#my-panels').outerHTML
 
-    expect(document.getElementById('my-panel').hasAttribute('aria-labelledby')).toBeTruthy()
+    coreTabs(tabs, 0, { dangerouslyPromiseToHandlePanels: true })
+
+    expect(initialHTML).toEqual(document.querySelector('#my-panels').outerHTML)
+  })
+  it('coreTabs with dangerouslyPromiseToHandleTabs should not modify panels', () => {
+    document.body.innerHTML = `
+    <div>
+      <div id="my-tabs">
+        <button id="tab-1" aria-controls="my-panel-1">Button tab 1</button>
+        <button id="tab-2" aria-controls="my-panel-2">Button tab 2</button>
+      </div>
+    </div>
+    <!-- Next element children will become panels of correlating tab -->
+    <div id="my-panels">
+      <div id="my-panel-1">Text of tab 1</div>
+      <div id="my-panel-2">Text of tab 2</div>
+    </div>`
+
+    const tabs = document.querySelector('#my-tabs')
+
+    const initialHTML = tabs.innerHTML
+
+    coreTabs(tabs, 0, { dangerouslyPromiseToHandleTabs: true })
+
+    // using innerHTML because we will modify tabs-element with data-* attrs
+    expect(initialHTML).toEqual(tabs.innerHTML)
+  })
+  it('setTabAttributes sets the correct attributes', () => {
+    document.body.innerHTML = `
+    <div>
+      <div id="my-tabs">
+        <button id="tab-1" aria-controls="panel-1">Button tab 1</button>
+        <button id="tab-2" aria-controls="panel-2">Button tab 2</button>
+      </div>
+    </div>
+    <!--
+      Putting tabs somewhere else in the DOM.
+
+      NB! there must not be any semantic content between tabs and panels.
+    -->
+    <div id="my-panels">
+      <div id="panel-1">Panel 1</div>
+      <div id="panel-2">Panel 2</div>
+    </div>`
+
+    const tabs = document.querySelector('#my-tabs')
+    coreTabs(tabs, 0, { dangerouslyPromiseToHandleTabs: true })
+
+    const tab1 = document.querySelector('#tab-1')
+    const tab2 = document.querySelector('#tab-2')
+
+    setTabAttributes(tab1, true)
+    setTabAttributes(tab2, false)
+
+    expectActiveTab(tab1, { controls: 'panel-1' })
+    expectInactiveTab(tab2, { controls: 'panel-2' })
+  })
+  it('setPanelAttributes sets the correct attributes', () => {
+    document.body.innerHTML = `
+    <div>
+      <div id="my-tabs">
+        <button id="tab-1" aria-controls="panel-1">Button tab 1</button>
+        <button id="tab-2" aria-controls="panel-2">Button tab 2</button>
+      </div>
+    </div>
+    <!--
+      Putting tabs somewhere else in the DOM.
+
+      NB! there must not be any semantic content between tabs and panels.
+    -->
+    <div id="my-panels">
+      <div id="panel-1">Panel 1</div>
+      <div id="panel-2">Panel 2</div>
+    </div>`
+    const tabs = document.querySelector('#my-tabs')
+
+    coreTabs(tabs, 0, { dangerouslyPromiseToHandldePanels: true })
+
+    const panel1 = document.querySelector('#panel-1')
+    const panel2 = document.querySelector('#panel-2')
+    const tab1 = document.querySelector('#tab-1')
+    const tab2 = document.querySelector('#tab-2')
+
+    setPanelAttributes(panel1, tab1, true)
+    setPanelAttributes(panel2, tab2, false)
+
+    expectActivePanel(panel1, { labelledby: 'tab-1' })
+    expectInactivePanel(panel2, { labelledby: 'tab-2' })
   })
 })

--- a/packages/core-toggle/core-toggle.test.js
+++ b/packages/core-toggle/core-toggle.test.js
@@ -1,4 +1,4 @@
-const toggle = require('./core-toggle.min.js')
+import toggle from './core-toggle'
 
 describe('toggle', () => {
   test('should exists', () => {

--- a/packages/utils.js
+++ b/packages/utils.js
@@ -77,7 +77,7 @@ export function getUUID (el) {
 /**
 * queryAll
 * @param {String|NodeList|Array|Element} elements A CSS selector string, nodeList, element array, or single element
-* @return {Array} Array of elements
+* @return {Element[]} Array of elements
 */
 export function queryAll (elements, context = document) {
   if (elements) {


### PR DESCRIPTION
Ludo er ekstremt sårbar for DOM-manipulasjoner, som flytting av taggen-taggen ludo lever i.

For å få korrekte a11y tagger på panelet ludo ligger i så eksponerer jeg noen nyttige funksjoner.