### PR TITLE
32 dialog strict type

### DIFF
--- a/packages/core-dialog/core-dialog.js
+++ b/packages/core-dialog/core-dialog.js
@@ -56,7 +56,7 @@ addEvent(UUID, 'transitionend', ({target}) => {
 addEvent(UUID, 'keydown', (event) => {
   const key = event.keyCode
   const dialog = !event.defaultPrevented && (key === KEYS.ESC || key === KEYS.TAB) && getTopLevelDialog()
-  const isStrict = dialog.getAttribute('data-dialog-type') === 'strict'
+  const isStrict = dialog && dialog.getAttribute('data-dialog-type') === 'strict'
 
   if (dialog && key === KEYS.TAB) keepFocus(dialog, event)
   if (dialog && !isStrict && key === KEYS.ESC) setOpen(dialog, false, event.preventDefault())

--- a/packages/core-dialog/core-dialog.js
+++ b/packages/core-dialog/core-dialog.js
@@ -25,6 +25,7 @@ export default function dialog (dialogs, open) {
     dialog.setAttribute('aria-modal', true)
     dialog.setAttribute('aria-label', options.label || dialog.getAttribute('aria-label'))
     hasBackdrop || dialog.insertAdjacentElement('afterend', document.createElement('backdrop'))
+    options.type && dialog.setAttribute('data-dialog-type', options.type)
 
     setOpen(dialog, options.open)
     return dialog
@@ -38,10 +39,11 @@ addEvent(UUID, 'click', (event) => {
   for (let el = event.target, isClose; el; el = el.parentElement) {
     const action = el.getAttribute(ATTR)
     const prev = el.previousElementSibling
+    const isStrict = prev && prev.hasAttribute(UUID) && prev.getAttribute('data-dialog-type') === 'strict'
     isClose = isClose || action === 'close'
 
     if (isClose) el.hasAttribute(UUID) && setOpen(el, false)
-    else if (prev && prev.hasAttribute(UUID)) setOpen(prev, false) // Click on backdrop
+    else if (!isStrict && prev && prev.hasAttribute(UUID)) setOpen(prev, false) // Click on backdrop
     else if (action) dialog(document.getElementById(action), true) // Target dialog
   }
 })
@@ -54,9 +56,10 @@ addEvent(UUID, 'transitionend', ({target}) => {
 addEvent(UUID, 'keydown', (event) => {
   const key = event.keyCode
   const dialog = !event.defaultPrevented && (key === KEYS.ESC || key === KEYS.TAB) && getTopLevelDialog()
+  const isStrict = dialog.getAttribute('data-dialog-type') === 'strict'
 
   if (dialog && key === KEYS.TAB) keepFocus(dialog, event)
-  if (dialog && key === KEYS.ESC) setOpen(dialog, false, event.preventDefault())
+  if (dialog && !isStrict && key === KEYS.ESC) setOpen(dialog, false, event.preventDefault())
 })
 
 const getZIndexOfElement = (element) =>

--- a/packages/core-dialog/core-dialog.jsx
+++ b/packages/core-dialog/core-dialog.jsx
@@ -6,14 +6,14 @@ const DEFAULTS = {hidden: null, onToggle: null}
 
 export default class Dialog extends React.Component {
   componentDidMount () {
-    dialog(this.el, this.props.open)
+    dialog(this.el, exclude(this.props, DEFAULTS))
     this.el.addEventListener('dialog.toggle', this.props.onToggle)
   }
   componentWillUnmount () {
     this.el.removeEventListener('dialog.toggle', this.props.onToggle)
   }
-  componentWillReceiveProps ({open}) {
-    dialog(this.el, open)
+  componentWillReceiveProps (props) {
+    dialog(this.el, exclude(props, DEFAULTS))
   }
   render () {
     return React.createElement('dialog',

--- a/packages/core-dialog/core-dialog.jsx
+++ b/packages/core-dialog/core-dialog.jsx
@@ -2,22 +2,22 @@ import React from 'react'
 import dialog from './core-dialog'
 import { exclude } from '../utils'
 
-const DEFAULTS = {hidden: null, onToggle: null}
-
 export default class Dialog extends React.Component {
+  static get defaultProps () { return {strict: null, onToggle: null} }
+
   componentDidMount () {
-    dialog(this.el, exclude(this.props, DEFAULTS))
+    dialog(this.el, this.props)
     this.el.addEventListener('dialog.toggle', this.props.onToggle)
   }
   componentWillUnmount () {
     this.el.removeEventListener('dialog.toggle', this.props.onToggle)
   }
   componentWillReceiveProps (props) {
-    dialog(this.el, exclude(props, DEFAULTS))
+    dialog(this.el, props)
   }
   render () {
     return React.createElement('dialog',
-      exclude(this.props, DEFAULTS, {ref: el => (this.el = el)}),
+      exclude(this.props, Dialog.defaultProps, {ref: el => (this.el = el)}),
       this.props.children)
   }
 }

--- a/packages/core-dialog/core-dialog.md
+++ b/packages/core-dialog/core-dialog.md
@@ -18,10 +18,18 @@ category: Components
   <p>Nunc mi felis, condimentum quis hendrerit sed, porta eget libero.</p>
   <button data-core-dialog="close">Close</button>
 </dialog>
+<button data-core-dialog="strict-dialog">Open strict dialog</button>
+<dialog id="strict-dialog" class="my-dialog" aria-label="første dialog tittel">
+  <h1>This is a title</h1>
+  <p>Nunc mi felis, condimentum quis hendrerit sed, porta eget libero. Aenean scelerisque ex eu nisi varius hendrerit. Suspendisse elementum quis massa at vehicula. Nulla lacinia mi pulvinar, venenatis nisi ut, commodo quam. Praesent egestas mi sit amet quam porttitor, mollis mattis mi rhoncus.</p>
+  <button data-core-dialog="close">Close</button>
+</dialog>
 <div id="docs-react-dialog"></div>
 ```
 ```dialog.js
-coreDialog('.my-dialog', {open: false, type: 'strict'})
+coreDialog('#my-dialog', {open: false})
+coreDialog('#my-dialog-nested', {open: false})
+coreDialog('#strict-dialog', {open: false, strict: true})
 coreInput('.my-input')
 ```
 ```dialog.jsx
@@ -31,14 +39,21 @@ class DialogContainerTest extends React.Component {
     super(props)
     this.state = {
       open: false,
+      strictOpen: false,
       contentTitle: 'Dialog for JSX'
     }
     this.toggleDialog = this.toggleDialog.bind(this)
+    this.toggleStrictDialog = this.toggleStrictDialog.bind(this)
     this.handleToggle = this.handleToggle.bind(this)
+    this.handleStrictToggle = this.handleStrictToggle.bind(this)
   }
 
   toggleDialog () {
     this.setState({open: !this.state.open})
+  }
+
+  toggleStrictDialog () {
+    this.setState({strictOpen: !this.state.strictOpen})
   }
 
   handleToggle (event) {
@@ -46,7 +61,13 @@ class DialogContainerTest extends React.Component {
     this.setState({open: !event.detail.isOpen})
   }
 
+  handleStrictToggle (event) {
+    event.preventDefault()
+    this.setState({strictOpen: !event.detail.isOpen})
+  }
+
   render () {
+    const isStrict = true
     return (
       <div>
         <button onClick={this.toggleDialog}>Open dialog jsx</button>
@@ -59,6 +80,18 @@ class DialogContainerTest extends React.Component {
           <h1>{this.state.contentTitle}</h1>
           <p>Nunc mi felis, condimentum quis hendrerit sed, porta eget libero. Aenean scelerisque ex eu nisi varius hendrerit. Suspendisse elementum quis massa at vehicula. Nulla lacinia mi pulvinar, venenatis nisi ut, commodo quam. Praesent egestas mi sit amet quam porttitor, mollis mattis mi rhoncus.</p>
           <button onClick={this.toggleDialog}>Lukk</button>
+        </Dialog>
+        <button onClick={this.toggleStrictDialog}>Open strict dialog jsx</button>
+        <Dialog
+          className="my-dialog"
+          open={this.state.strictOpen}
+          onToggle={this.handleStrictToggle}
+          aria-label="React dialog"
+          strict="true"
+        >
+          <h1>{this.state.contentTitle}</h1>
+          <p>Nunc mi felis, condimentum quis hendrerit sed, porta eget libero. Aenean scelerisque ex eu nisi varius hendrerit. Suspendisse elementum quis massa at vehicula. Nulla lacinia mi pulvinar, venenatis nisi ut, commodo quam. Praesent egestas mi sit amet quam porttitor, mollis mattis mi rhoncus.</p>
+          <button onClick={this.toggleStrictDialog}>Lukk</button>
         </Dialog>
       </div>
     )
@@ -124,6 +157,7 @@ import coreDialog from '@nrk/core-dialog'
 // Initialize a specific component or multiple components
 coreDialog(String|Element|Elements, { // Accepts a selector string, NodeList, Element or array of Elements
   open: null,                         // Defaults to true if open is set, otherwise false. Use true|false to force open state
+  strict: true|false,                 // Defaults to false. If set to true the dialog will not close on ESC-key nor on click on backdrop
   label: ''                           // Defaults to aria-label if set or an empty string. Should be implemented in order for the dialog to have a label readable by screen readers
 })
 
@@ -135,7 +169,7 @@ coreDialog('.my-dialog', {open: true, label: 'A super dialog'})
 ```jsx
 import Dialog from '@nrk/core-dialog/jsx'
 
-<Dialog open={true|false} onToggle={function(){}} aria-label="Title of dialog">
+<Dialog open={true|false} strict={'true'| /*or omit attribute*/} onToggle={function(){}} aria-label="Title of dialog">
   <h1>My React/Preact dialog</h1>
   <p>Some content</p>
   <button onClick={closeDialog}></button>

--- a/packages/core-dialog/core-dialog.md
+++ b/packages/core-dialog/core-dialog.md
@@ -87,7 +87,7 @@ class DialogContainerTest extends React.Component {
           open={this.state.strictOpen}
           onToggle={this.handleStrictToggle}
           aria-label="React dialog"
-          strict="true"
+          strict
         >
           <h1>{this.state.contentTitle}</h1>
           <p>Nunc mi felis, condimentum quis hendrerit sed, porta eget libero. Aenean scelerisque ex eu nisi varius hendrerit. Suspendisse elementum quis massa at vehicula. Nulla lacinia mi pulvinar, venenatis nisi ut, commodo quam. Praesent egestas mi sit amet quam porttitor, mollis mattis mi rhoncus.</p>
@@ -169,7 +169,7 @@ coreDialog('.my-dialog', {open: true, label: 'A super dialog'})
 ```jsx
 import Dialog from '@nrk/core-dialog/jsx'
 
-<Dialog open={true|false} strict={'true'| /*or omit attribute*/} onToggle={function(){}} aria-label="Title of dialog">
+<Dialog open={true|false} strict={true|false} onToggle={function(){}} aria-label="Title of dialog">
   <h1>My React/Preact dialog</h1>
   <p>Some content</p>
   <button onClick={closeDialog}></button>

--- a/packages/core-dialog/core-dialog.md
+++ b/packages/core-dialog/core-dialog.md
@@ -21,7 +21,7 @@ category: Components
 <div id="docs-react-dialog"></div>
 ```
 ```dialog.js
-coreDialog('.my-dialog', false)
+coreDialog('.my-dialog', {open: false, type: 'strict'})
 coreInput('.my-input')
 ```
 ```dialog.jsx

--- a/packages/core-dialog/core-dialog.md
+++ b/packages/core-dialog/core-dialog.md
@@ -39,21 +39,14 @@ class DialogContainerTest extends React.Component {
     super(props)
     this.state = {
       open: false,
-      strictOpen: false,
       contentTitle: 'Dialog for JSX'
     }
     this.toggleDialog = this.toggleDialog.bind(this)
-    this.toggleStrictDialog = this.toggleStrictDialog.bind(this)
     this.handleToggle = this.handleToggle.bind(this)
-    this.handleStrictToggle = this.handleStrictToggle.bind(this)
   }
 
   toggleDialog () {
     this.setState({open: !this.state.open})
-  }
-
-  toggleStrictDialog () {
-    this.setState({strictOpen: !this.state.strictOpen})
   }
 
   handleToggle (event) {
@@ -61,13 +54,7 @@ class DialogContainerTest extends React.Component {
     this.setState({open: !event.detail.isOpen})
   }
 
-  handleStrictToggle (event) {
-    event.preventDefault()
-    this.setState({strictOpen: !event.detail.isOpen})
-  }
-
   render () {
-    const isStrict = true
     return (
       <div>
         <button onClick={this.toggleDialog}>Open dialog jsx</button>
@@ -81,24 +68,49 @@ class DialogContainerTest extends React.Component {
           <p>Nunc mi felis, condimentum quis hendrerit sed, porta eget libero. Aenean scelerisque ex eu nisi varius hendrerit. Suspendisse elementum quis massa at vehicula. Nulla lacinia mi pulvinar, venenatis nisi ut, commodo quam. Praesent egestas mi sit amet quam porttitor, mollis mattis mi rhoncus.</p>
           <button onClick={this.toggleDialog}>Lukk</button>
         </Dialog>
-        <button onClick={this.toggleStrictDialog}>Open strict dialog jsx</button>
+      </div>
+    )
+  }
+}
+
+class StrictDialogContainerTest extends React.Component {
+  constructor (props) {
+    super(props);
+    this.state = {
+      open: false,
+      contentTitle: 'Strict dialog for JSX'
+    }
+    this.toggleDialog = this.toggleDialog.bind(this)
+  }
+
+  toggleDialog () {
+    this.setState({open: !this.state.open})
+  }
+  
+  render () {
+    return (
+      <div>
+        <button data-core-dialog="dialog-jsx">Open strict dialog jsx</button>
         <Dialog
+          id="dialog-jsx"
           className="my-dialog"
-          open={this.state.strictOpen}
           onToggle={this.handleStrictToggle}
           aria-label="React dialog"
           strict
         >
           <h1>{this.state.contentTitle}</h1>
           <p>Nunc mi felis, condimentum quis hendrerit sed, porta eget libero. Aenean scelerisque ex eu nisi varius hendrerit. Suspendisse elementum quis massa at vehicula. Nulla lacinia mi pulvinar, venenatis nisi ut, commodo quam. Praesent egestas mi sit amet quam porttitor, mollis mattis mi rhoncus.</p>
-          <button onClick={this.toggleStrictDialog}>Lukk</button>
+          <button data-core-dialog="close">Lukk</button>
         </Dialog>
       </div>
     )
   }
 }
 
-<DialogContainerTest />
+<div>
+  <DialogContainerTest />
+  <StrictDialogContainerTest />
+</div>
 ```
 ```dialog.css
 .my-dialog h1 { margin-top: 0 }


### PR DESCRIPTION
Fixes https://github.com/nrkno/core-components/issues/31

I'm not completely satisfied with `strict={'true'| /*or omit attribute*/} ` on line 172 in `core-dialog.md`. I want to either send in `strict={true|false}` (as booleans and not strings), but I'm getting an error. Any suggestions @eirikbacker 