### PR TITLE
core-scroll: Allow small movements while clicking.

### DIFF
--- a/packages/core-scroll/core-scroll.js
+++ b/packages/core-scroll/core-scroll.js
@@ -11,6 +11,8 @@ const VELOCITY = 20
 // https://css-tricks.com/introduction-reduced-motion-media-query/
 const requestJump = IS_BROWSER && window.matchMedia && window.matchMedia('(prefers-reduced-motion)').matches
 
+const SIGNIFICANT_DRAG_THRESHOLD = 10
+
 export default function scroll (elements, move = '') {
   const options = typeof move === 'object' ? move : {move}
   const isChange = 'x' in options || 'y' in options || options.move
@@ -63,12 +65,28 @@ function onMousedown (event) {
   }
 }
 
+/**
+ * Check that the current drag is significant.
+ *
+ * When the user clicks on an element and the cursor moves slightly, it is most
+ * likely that the user wanted to click in stead of drag.
+ */
+function isSignificantDrag () {
+  return (
+    DRAG.target != null &&
+    (Math.abs(DRAG.scrollX) > SIGNIFICANT_DRAG_THRESHOLD ||
+      Math.abs(DRAG.scrollY) > SIGNIFICANT_DRAG_THRESHOLD)
+  )
+}
+
 function onMousemove (event) {
   DRAG.diffX = DRAG.pageX - (DRAG.pageX = event.pageX)
   DRAG.diffY = DRAG.pageY - (DRAG.pageY = event.pageY)
   DRAG.target.scrollLeft = DRAG.scrollX += DRAG.diffX
   DRAG.target.scrollTop = DRAG.scrollY += DRAG.diffY
-  DRAG.target.style.pointerEvents = 'none' // Prevent links when we know there has been movement
+  if (isSignificantDrag()) {
+    DRAG.target.style.pointerEvents = 'none' // Prevent links when we know there has been movement
+  }
 }
 
 function onMouseup (event) {

--- a/packages/core-scroll/core-scroll.js
+++ b/packages/core-scroll/core-scroll.js
@@ -5,13 +5,12 @@ const DRAG = {}
 const ATTR = 'data-core-scroll'
 const UUID = `data-${name}-${version}`.replace(/\W+/g, '-') // Strip invalid attribute characters
 const MOVE = {up: {y: -1, prop: 'top'}, down: {y: 1, prop: 'bottom'}, left: {x: -1}, right: {x: 1}}
+const THRESHOLD = 3 // Mouse needs to move 3px per frame to stop click events
 const FRICTION = 0.8
 const VELOCITY = 20
 
 // https://css-tricks.com/introduction-reduced-motion-media-query/
 const requestJump = IS_BROWSER && window.matchMedia && window.matchMedia('(prefers-reduced-motion)').matches
-
-const SIGNIFICANT_DRAG_THRESHOLD = 10
 
 export default function scroll (elements, move = '') {
   const options = typeof move === 'object' ? move : {move}
@@ -65,26 +64,14 @@ function onMousedown (event) {
   }
 }
 
-/**
- * Check that the current drag is significant.
- *
- * When the user clicks on an element and the cursor moves slightly, it is most
- * likely that the user wanted to click in stead of drag.
- */
-function isSignificantDrag () {
-  return (
-    DRAG.target != null &&
-    (Math.abs(DRAG.scrollX) > SIGNIFICANT_DRAG_THRESHOLD ||
-      Math.abs(DRAG.scrollY) > SIGNIFICANT_DRAG_THRESHOLD)
-  )
-}
-
 function onMousemove (event) {
   DRAG.diffX = DRAG.pageX - (DRAG.pageX = event.pageX)
   DRAG.diffY = DRAG.pageY - (DRAG.pageY = event.pageY)
   DRAG.target.scrollLeft = DRAG.scrollX += DRAG.diffX
   DRAG.target.scrollTop = DRAG.scrollY += DRAG.diffY
-  if (isSignificantDrag()) {
+
+   // Small movements is likelig a click and not a drag
+  if (Math.abs(DRAG.diffX) > THRESHOLD || Math.abs(DRAG.diffY) > THRESHOLD) {
     DRAG.target.style.pointerEvents = 'none' // Prevent links when we know there has been movement
   }
 }


### PR DESCRIPTION
When the user clicks on an element and the cursor moves slightly, it is most
likely that the user wanted to click in stead of drag.

Currently, as reported by users, they have a hard time clicking on elements
inside a element controlled by core-scroll. It is hard to know exactly why, but
if they are moving their cursor, even 1px while clicking on an element the
click is prevented. This commit addresses that issue.