### PR TITLE
core-scroll: Allow small movements while clicking.

### DIFF
--- a/packages/core-scroll/core-scroll.js
+++ b/packages/core-scroll/core-scroll.js
@@ -5,13 +5,12 @@ const DRAG = {}
 const ATTR = 'data-core-scroll'
 const UUID = `data-${name}-${version}`.replace(/\W+/g, '-') // Strip invalid attribute characters
 const MOVE = {up: {y: -1, prop: 'top'}, down: {y: 1, prop: 'bottom'}, left: {x: -1}, right: {x: 1}}
+const SIGNIFICANT_DRAG_THRESHOLD = 10
 const FRICTION = 0.8
 const VELOCITY = 20
 
 // https://css-tricks.com/introduction-reduced-motion-media-query/
 const requestJump = IS_BROWSER && window.matchMedia && window.matchMedia('(prefers-reduced-motion)').matches
-
-const SIGNIFICANT_DRAG_THRESHOLD = 10
 
 export default function scroll (elements, move = '') {
   const options = typeof move === 'object' ? move : {move}


### PR DESCRIPTION
When the user clicks on an element and the cursor moves slightly, it is most
likely that the user wanted to click in stead of drag.

Currently, as reported by users, they have a hard time clicking on elements
inside a element controlled by core-scroll. It is hard to know exactly why, but
if they are moving their cursor, even 1px while clicking on an element the
click is prevented. This commit addresses that issue.