### PR TITLE
Fix Edge issue where target in transisionend can be document

### DIFF
--- a/packages/core-dialog/core-dialog.js
+++ b/packages/core-dialog/core-dialog.js
@@ -49,8 +49,8 @@ addEvent(UUID, 'click', (event) => {
 })
 
 // Ensure focus is set after animations
-addEvent(UUID, 'transitionend', ({ target }) => {
-  if (target.hasAttribute(UUID) && target.hasAttribute('open')) setFocus(target)
+addEvent(UUID, 'transitionend', ({ target }) => { // NB: target can be document
+  if (target.hasAttribute && target.hasAttribute(UUID) && target.hasAttribute('open')) setFocus(target)
   else if (OPENER) setTimeout(() => (OPENER = OPENER && OPENER.focus()), 16) // Move focus after paint
 })
 


### PR DESCRIPTION
since transitionend can have event.target document, the target.hasAttribute was occasionally throwing an error