### PR TITLE
Add support React children that may be null

### DIFF
--- a/packages/core-tabs/core-tabs.jsx
+++ b/packages/core-tabs/core-tabs.jsx
@@ -23,11 +23,13 @@ export default class Tabs extends React.Component {
     return React.createElement('div', attr,
       React.Children.map(this.props.children, (group, isPanelGroup) => {
         if (isPanelGroup < 2) {
-          return React.cloneElement(group, null, React.Children.map(group.props.children, (child, index) =>
-            React.cloneElement(child, isPanelGroup
-              ? { hidden: open !== index }
-              : { 'aria-selected': open === index })
-          ))
+          return React.cloneElement(group, null, React.Children.toArray(group.props.children)
+            .filter(Boolean)
+            .map((child, index) =>
+              React.cloneElement(child, isPanelGroup
+                ? { hidden: open !== index }
+                : { 'aria-selected': open === index })
+            ))
         }
         return group
       })

--- a/packages/core-tabs/core-tabs.test.jsx
+++ b/packages/core-tabs/core-tabs.test.jsx
@@ -3,80 +3,68 @@ const React = require('react')
 const ReactDOM = require('react-dom')
 const Tabs = require('./jsx')
 
-const expectActiveTab = (tab) => {
-  expect(tab.getAttribute('aria-selected')).toEqual('true')
-}
-const expectInactiveTab = (tab) => {
-  expect(tab.getAttribute('aria-selected')).toEqual('false')
-}
-const expectActivePanel = (panel) => {
-  expect(panel.hasAttribute('hidden')).toBeFalsy()
-}
-const expectInactivePanel = (panel) => {
-  expect(panel.hasAttribute('hidden')).toBeTruthy()
-}
-
-const mount = (props = {}, keepInstance) => {
-  if (!keepInstance) {
-    document.body.innerHTML = '<div id="mount"></div>'
-  }
-  const mount = document.getElementById('mount')
-  return ReactDOM.render(
+const TabsWithTwoPanels = props => {
+  return (
     <Tabs open={props.open} onToggle={props.onToggle}>
       <div>
         <button id='tab-1'>Tab 1</button>
-        <a href='#' id='tab-2'>Tab 2</a>
+        <a href='#' id='tab-2'>
+          Tab 2
+        </a>
       </div>
       <div>
         <div id='panel-1'>Panel 1</div>
         <div id='panel-2'>Panel 2</div>
       </div>
-    </Tabs>, mount)
+    </Tabs>
+  )
 }
 
 describe('core-tabs/jsx', () => {
-  it('should have default props', () => {
-    const wrapper = mount()
+  beforeEach(() => {
+    cleanUpDOM()
+  })
 
-    expect(wrapper.props.open).toBeNull()
-    expect(wrapper.props.onToggle).toBeNull()
+  it('should have default props', () => {
+    expect(Tabs.defaultProps.open).toBeNull()
+    expect(Tabs.defaultProps.onToggle).toBeNull()
   })
 
   it('should select first tab as default', () => {
-    mount()
+    mount(<TabsWithTwoPanels />)
 
-    expectActiveTab(document.getElementById('tab-1'))
-    expectActivePanel(document.getElementById('panel-1'))
-    expectInactiveTab(document.getElementById('tab-2'))
-    expectInactivePanel(document.getElementById('panel-2'))
+    expectActiveTab('tab-1')
+    expectActivePanel('panel-1')
+    expectInactiveTab('tab-2')
+    expectInactivePanel('panel-2')
   })
 
   it('should use prop to select on initial render', () => {
-    mount({ open: 1 })
+    mount(<TabsWithTwoPanels open={1} />)
 
-    expectInactiveTab(document.getElementById('tab-1'))
-    expectInactivePanel(document.getElementById('panel-1'))
-    expectActiveTab(document.getElementById('tab-2'))
-    expectActivePanel(document.getElementById('panel-2'))
+    expectInactiveTab('tab-1')
+    expectInactivePanel('panel-1')
+    expectActiveTab('tab-2')
+    expectActivePanel('panel-2')
   })
 
   it('should be able to handle prop updates', () => {
-    mount()
+    mount(<TabsWithTwoPanels />)
 
     // tab1 is selected by default, but we change it after initial render.
-    mount({ open: 1 }, true)
+    mount(<TabsWithTwoPanels open={1} />)
 
-    expectInactiveTab(document.getElementById('tab-1'))
-    expectInactivePanel(document.getElementById('panel-1'))
-    expectActiveTab(document.getElementById('tab-2'))
-    expectActivePanel(document.getElementById('panel-2'))
+    expectInactiveTab('tab-1')
+    expectInactivePanel('panel-1')
+    expectActiveTab('tab-2')
+    expectActivePanel('panel-2')
   })
 
   it('should able to handle onToggle prop updates', () => {
     const onToggleInitial = jest.fn()
     const onToggleExpected = jest.fn()
-    mount({ onToggle: onToggleInitial })
-    mount({ onToggle: onToggleExpected }, true)
+    mount(<TabsWithTwoPanels onToggle={onToggleInitial} />)
+    mount(<TabsWithTwoPanels onToggle={onToggleExpected} />)
 
     document.getElementById('tab-2').click()
 
@@ -85,22 +73,20 @@ describe('core-tabs/jsx', () => {
   })
 
   it('should support conditional rendering of panels', () => {
-    document.body.innerHTML = '<div id="mount"></div>'
-    const mount = document.getElementById('mount')
     const shouldDisplayTwo = false
 
-    ReactDOM.render(
+    mount(
       <Tabs>
         <div>
           <button id='tab-1'>Tab 1</button>
           {shouldDisplayTwo && <button id='tab-2'>Tab 2</button>}
-
         </div>
         <div>
           <div id='panel-1'>Panel 1</div>
           {shouldDisplayTwo && <div id='panel-2'>Panel 2</div>}
         </div>
-      </Tabs>, mount)
+      </Tabs>
+    )
 
     expect(document.getElementById('panel-2')).toBeNull()
     expect(document.getElementById('tab-2')).toBeNull()
@@ -110,11 +96,9 @@ describe('core-tabs/jsx', () => {
   })
 
   it('should have open prop that indexes based on what is rendered - not declared', () => {
-    document.body.innerHTML = '<div id="mount"></div>'
-    const mount = document.getElementById('mount')
     const shouldDisplayTwo = false
 
-    ReactDOM.render(
+    mount(
       <Tabs open={1}>
         <div>
           <button id='tab-1'>Tab 1</button>
@@ -126,12 +110,43 @@ describe('core-tabs/jsx', () => {
           {shouldDisplayTwo && <div id='panel-2'>Panel 2</div>}
           <div id='panel-3'>Panel 3</div>
         </div>
-      </Tabs>, mount)
+      </Tabs>
+    )
 
-    expectActiveTab(document.getElementById('tab-3'))
-    expectActivePanel(document.getElementById('panel-3'))
+    expectActiveTab('tab-3')
+    expectActivePanel('panel-3')
 
-    expectInactiveTab(document.getElementById('tab-1'))
-    expectInactivePanel(document.getElementById('panel-1'))
+    expectInactiveTab('tab-1')
+    expectInactivePanel('panel-1')
   })
 })
+
+const rootElementId = 'mount'
+
+function cleanUpDOM () {
+  document.body.innerHTML = `<div id="${rootElementId}"></div>`
+}
+
+function mount (component) {
+  return ReactDOM.render(component, document.getElementById(rootElementId))
+}
+
+function expectActiveTab (tabId) {
+  const tab = document.getElementById(tabId)
+  expect(tab.getAttribute('aria-selected')).toEqual('true')
+}
+
+function expectInactiveTab (tabId) {
+  const tab = document.getElementById(tabId)
+  expect(tab.getAttribute('aria-selected')).toEqual('false')
+}
+
+function expectActivePanel (panelId) {
+  const panel = document.getElementById(panelId)
+  expect(panel.hasAttribute('hidden')).toBeFalsy()
+}
+
+function expectInactivePanel (panelId) {
+  const panel = document.getElementById(panelId)
+  expect(panel.hasAttribute('hidden')).toBeTruthy()
+}

--- a/packages/core-tabs/core-tabs.test.jsx
+++ b/packages/core-tabs/core-tabs.test.jsx
@@ -83,4 +83,55 @@ describe('core-tabs/jsx', () => {
     expect(onToggleInitial).toHaveBeenCalledTimes(0)
     expect(onToggleExpected).toHaveBeenCalledTimes(1)
   })
+
+  it('should support conditional rendering of panels', () => {
+    document.body.innerHTML = '<div id="mount"></div>'
+    const mount = document.getElementById('mount')
+    const shouldDisplayTwo = false
+
+    ReactDOM.render(
+      <Tabs>
+        <div>
+          <button id='tab-1'>Tab 1</button>
+          {shouldDisplayTwo && <button id='tab-2'>Tab 2</button>}
+
+        </div>
+        <div>
+          <div id='panel-1'>Panel 1</div>
+          {shouldDisplayTwo && <div id='panel-2'>Panel 2</div>}
+        </div>
+      </Tabs>, mount)
+
+    expect(document.getElementById('panel-2')).toBeNull()
+    expect(document.getElementById('tab-2')).toBeNull()
+
+    expect(document.getElementById('panel-1')).not.toBeNull()
+    expect(document.getElementById('tab-1')).not.toBeNull()
+  })
+
+  it('should have open prop that indexes based on what is rendered - not declared', () => {
+    document.body.innerHTML = '<div id="mount"></div>'
+    const mount = document.getElementById('mount')
+    const shouldDisplayTwo = false
+
+    ReactDOM.render(
+      <Tabs open={1}>
+        <div>
+          <button id='tab-1'>Tab 1</button>
+          {shouldDisplayTwo && <button id='tab-2'>Tab 2</button>}
+          <button id='tab-3'>Tab 3</button>
+        </div>
+        <div>
+          <div id='panel-1'>Panel 1</div>
+          {shouldDisplayTwo && <div id='panel-2'>Panel 2</div>}
+          <div id='panel-3'>Panel 3</div>
+        </div>
+      </Tabs>, mount)
+
+    expectActiveTab(document.getElementById('tab-3'))
+    expectActivePanel(document.getElementById('panel-3'))
+
+    expectInactiveTab(document.getElementById('tab-1'))
+    expectInactivePanel(document.getElementById('panel-1'))
+  })
 })


### PR DESCRIPTION
* This enables consumers to pass null/undefined/false as panels that
  won't be rendered
* Resolves #180