### PR TITLE
clean up docs

### DIFF
--- a/packages/core-datepicker/readme.md
+++ b/packages/core-datepicker/readme.md
@@ -1,11 +1,6 @@
 # Core Datepicker
 
-> `@nrk/core-datepicker` enhances all child `input`, `select` `table` and `button` elements with keyboard accessible functionality for selecting date and time. The interface and granularity of date refinement can easily be altered through markup.
-
-- Handles both date and time selection
-- Add or remove controls to fit your needs
-- Keyboard accessible
-
+> `@nrk/core-datepicker` enhances all child `input`, `select` `table` and `button` elements with keyboard accessible functionality for selecting both dates and times. The interface and granularity of date refinement can easily be altered through markup.
 
 
 ## Installation
@@ -15,10 +10,8 @@ npm install @nrk/core-datepicker --save-exact
 ```
 ```js
 import coreDatepicker from '@nrk/core-datepicker'     // Vanilla JS
-import CoreDatepicker from '@nrk/core-datepicker/jsx' // ...or React/Preact compatible JSX
+import CoreDatepicker from '@nrk/core-datepicker/jsx' // React/Preact JSX
 ```
-
-
 
 <!--demo
 <script src="core-toggle/core-toggle.min.js"></script>
@@ -166,6 +159,7 @@ demo-->
 
 
 ## Usage
+
 All date values - both HTML markup and JavaScript - accepts accepts dates as numbers, or as natural language in [the format of @nrk/simple-date-parse](https://github.com/nrkno/simple-date-parse).
 
 ### HTML / JavaScript
@@ -223,7 +217,7 @@ coreDatepicker(
   String|Element|Elements, // Accepts a selector string, NodeList, Element or array of Elements
   String|Date              // Specify the date which coreDatepicker should use.
   // e.g:
-  'now + 2 days'           // Will set the date to the day after tomorrow  
+  'now + 2 days'           // Will set the date to the day after tomorrow
 })
 ```
 
@@ -295,7 +289,7 @@ A utility function for parsing time and dates. It's really just [`@nrk/simple-da
 coreDatepicker.parse('fri')
 ```
 
-## Language
+## Properties
 
 `@nrk/core-datepicker` defaults to Norwegian Bookmål text without abbreviations (writing `September` instead of `Sept`). This can be configured by setting the `days` and `months` properties. Note that abbreviations should always be at least 3 characters long to ensure a better experience for screen reader users (for instance writing `Mon`, `Tue`... instead of `m`, `t`...).
 
@@ -322,4 +316,3 @@ CoreDatepicker.months = ['jan', 'feb', ...] // Change name of months
 .my-datepicker button[aria-disabled="true"] /* Target dates from next or previous month in the month view */
 .my-datepicker button[data-core-datepicker-selected="true"]  /* Target the chosen date in month view */
 ```
-

--- a/packages/core-dialog/readme.md
+++ b/packages/core-dialog/readme.md
@@ -11,7 +11,7 @@ npm install @nrk/core-dialog --save-exact
 ```
 ```js
 import coreDialog from '@nrk/core-dialog'     // Vanilla JS
-import CoreDialog from '@nrk/core-dialog/jsx' // ...or React/Preact compatible JSX
+import CoreDialog from '@nrk/core-dialog/jsx' // React/Preact JSX
 ```
 
 
@@ -194,16 +194,18 @@ demo-->
 ```js
 import coreDialog from '@nrk/core-dialog'
 
-// Initialize a specific component or multiple components
+// Initialize one element or multiple elements
 coreDialog(String|Element|Elements, { // Accepts a selector string, NodeList, Element or array of Elements
-  open: null,                         // Defaults to true if open is set, otherwise false. Use true|false to force open state
-  strict: true|false,                 // Defaults to false. If set to true the dialog will not close on ESC-key nor on click on backdrop
-  label: ''                           // Defaults to aria-label if set or an empty string. Should be implemented in order for the dialog to have a label readable by screen readers
+  open: Boolean,                      // Optional. Defaults to true. Use to force open state
+  strict: Boolean,                    // Optional. Defaults to false. If true the dialog will not close on ESC-key nor on click on backdrop
+  label: String                       // Optional. Defaults to aria-label if set or ''. Should be implemented in order for the dialog to have a label readable by screen readers
+  opener: Element                     // Optional. Defaults to document.activeElement. Sets the element that should receive focus after closing
 })
 
-// Example:
-coreDialog('.my-dialog')
-coreDialog('.my-dialog', {open: true, label: 'A super dialog'})
+// Examples:
+coreDialog('.my-dialog')              // Initialize dialog
+coreDialog('.my-dialog', true)        // Initialize dialog with 'open' set to true
+coreDialog('.my-dialog', { open: true, label: 'A super dialog' }) // Initialize dialog with options
 ```
 
 ### React / Preact

--- a/packages/core-input/readme.md
+++ b/packages/core-input/readme.md
@@ -58,8 +58,7 @@ demo-->
 
 ## Usage
 
-Typing toggles the [hidden attribute](https://developer.mozilla.org/en/docs/Web/HTML/Global_attributes/hidden) on items of type `<button>` and `<a>`, based on matching [textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent). Focusing the input unhides the following element.
-The default filtering behavior can easily be altered through the `'input.select'` and `'input.filter'` [events](#events).
+Typing toggles the [hidden attribute](https://developer.mozilla.org/en/docs/Web/HTML/Global_attributes/hidden) on items of type `<button>` and `<a>`, based on matching [textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent). Focusing the input unhides the following element. The default filtering behavior can easily be altered through the The default filtering behavior can easily be altered through the `'input.select'`, `'input.filter'`, `'input.ajax'` and  `'input.ajax.beforeSend'` [events](#events). 
 
 Results will be rendered in the element directly after the `<input>`.
 Always use `coreInput.escapeHTML(String)` to safely render data from API or user.
@@ -96,7 +95,7 @@ import CoreInput from '@nrk/core-input/jsx'
 
 // All props are optional, and defaults are shown below
 // Props like className, style, etc. will be applied as actual attributes
-// <Input> will handle state itself unless you call event.preventDefault() in onToggle
+// <CoreInput> will handle state itself unless you call event.preventDefault() in onFilter, onSelect or onAjax
 
 <CoreInput open={false} onFilter={(event) => {}} onSelect={(event) => {}} onAjax={(event) => {}} ajax="https://search.com?q={{value}}">
   <input type="text" />   // First element must result in a input-tag. Accepts both elements and components

--- a/packages/core-input/readme.md
+++ b/packages/core-input/readme.md
@@ -11,10 +11,8 @@ npm install @nrk/core-input --save-exact
 ```
 ```js
 import coreInput from '@nrk/core-input'     // Vanilla JS
-import CoreInput from '@nrk/core-input/jsx' // ...or React/Preact compatible JSX
+import CoreInput from '@nrk/core-input/jsx' // React/Preact JSX
 ```
-
-
 
 <!--demo
 <script src="core-input/core-input.min.js"></script>
@@ -23,8 +21,6 @@ import CoreInput from '@nrk/core-input/jsx' // ...or React/Preact compatible JSX
 demo-->
 
 ## Demo
-
-Typing toggles the [hidden attribute](https://developer.mozilla.org/en/docs/Web/HTML/Global_attributes/hidden) on items of type `<button>` and `<a>`, based on matching [textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent). The default filtering behavior can easily be altered through the `'input.select'` and `'input.filter'` [events](#events).
 
 ```html
 <!--demo-->
@@ -62,13 +58,17 @@ Typing toggles the [hidden attribute](https://developer.mozilla.org/en/docs/Web/
 
 ## Usage
 
+Typing toggles the [hidden attribute](https://developer.mozilla.org/en/docs/Web/HTML/Global_attributes/hidden) on items of type `<button>` and `<a>`, based on matching [textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent). Focusing the input unhides the following element.
+The default filtering behavior can easily be altered through the `'input.select'` and `'input.filter'` [events](#events).
+
+Results will be rendered in the element directly after the `<input>`.
+Always use `coreInput.escapeHTML(String)` to safely render data from API or user.
+
 ### HTML / JavaScript
 
-<small><b>Important:</b> Always use `coreInput.escapeHTML(String)` to safely render data from API or user.</small>
-<small><b>Important:</b> Results will always be rendered in the element directly after the `<input>`</small>
 
 ```html
-<input type="text" class="my-input">                  <!-- Input element must be a <input> -->
+<input type="text" class="my-input">                  <!-- Input element must be a textual <input> -->
 <ul hidden>                                           <!-- Can be any tag, but items should be inside <li> -->
   <li><button>Item 1</button></li>                    <!-- Items must be <button> or <a> -->
   <li><button value="Suprise!">Item 2</button></li>   <!-- Alternative value can be defined -->
@@ -79,31 +79,29 @@ Typing toggles the [hidden attribute](https://developer.mozilla.org/en/docs/Web/
 import coreInput from '@nrk/core-input'
 
 coreInput(String|Element|Elements, {    // Accepts a selector string, NodeList, Element or array of Elements
-  open: null,                           // Optional. Defaults to value of aria-expanded. Use true|false to force open state
-  content: null,                        // Optional. Set String of HTML content. HTML is used for full flexibility on markup
-  ajax: null                            // Optional. Fetch external data, example: "https://search.com?q={{value}}"
+  open: Boolean,                        // Optional. Defaults to value of aria-expanded. Use to force open state
+  content: String,                      // Optional. Set String of HTML content. HTML is used for full flexibility on markup
+  ajax: String                          // Optional. Fetch external data, example: "https://search.com?q={{value}}"
 })
 
-// Helpers:
+// Passing a string as second argument sets the 'content' option
 coreInput('.my-input', '<li><a href="?q=' + coreInput.escapeHTML(input.value) + '">More results</a></li>') // escape html
 coreInput('.my-input', '<li><button>' + coreInput.highlight(item.text, input.value) + '</button></li>') // highlight match
 ```
 
 ### React / Preact
 
-<small><b>Important:</b> First direct of `<CoreToggle>` must be a `<input>` and next direct child  will be used for results</small>
-
 ```js
 import CoreInput from '@nrk/core-input/jsx'
 
 // All props are optional, and defaults are shown below
 // Props like className, style, etc. will be applied as actual attributes
-// <Input> will handle state itself unless you call event.preventDefault() in onFilter or onSelect
+// <Input> will handle state itself unless you call event.preventDefault() in onToggle
 
 <CoreInput open={false} onFilter={(event) => {}} onSelect={(event) => {}} onAjax={(event) => {}} ajax="https://search.com?q={{value}}">
-  <input type="text" />   <!-- First element must result in a input-tag. Accepts both elements and components -->
+  <input type="text" />   // First element must result in a input-tag. Accepts both elements and components
   <ul>                    // Next element will be used for items. Accepts both elements and components
-    <li><button>Item 1</button></li>                  <!-- Interactive items must be <button> or <a> -->
+    <li><button>Item 1</button></li>                  // Interactive items must be <button> or <a>
     <li><button value="Suprise!">Item 2</button></li> // Alternative value can be defined
     <li><a href="https://www.nrk.no/">NRK.no</a></li> // Actual links are recommended when applicable
   </ul>
@@ -189,11 +187,11 @@ All styling in documentation is example only. Both the `<button>` and content el
 
 
 
-## Ajax
+## Notes
+
+### Ajax
 
 When using `@nrk/core-input` with the `ajax: https://search.com?q={{value}}` functionality, make sure to implement both a `Searching...` status (while fetching data from the server), and a `No hits` status (if server responds with no results). These status indicators are highly recommended, but not provided by default as the context of use will affect the optimal textual formulation. [See example implementation →](#demo-ajax)
-
-### Customise the request
 
 If you need to alter default headers, request method or post data, use the [`input.ajax.beforeSend` event  →](#input-ajax-beforesend)
 

--- a/packages/core-progress/readme.md
+++ b/packages/core-progress/readme.md
@@ -11,7 +11,7 @@ npm install @nrk/core-progress --save-exact
 ```
 ```js
 import coreProgress from '@nrk/core-progress'     // Vanilla JS
-import coreProgress from '@nrk/core-progress/jsx' // ...or React/Preact compatible JSX
+import coreProgress from '@nrk/core-progress/jsx' // React/Preact JSX
 ```
 
 
@@ -81,19 +81,16 @@ demo-->
 
 ```js
 coreProgress(
-  selector, // Selector string or HTML Element
-  value // See table below
-);
+  String|Element|Elements,  // Accepts a selector string, NodeList, Element or array of Elements
+  Number|String|Object      // Optional. Set value, indeterminate status or options
+)
+
+// Examples:
+coreProgress('.my-progress')                         // Initalize tabs on element
+coreProgress('.my-progress', 1)                      // Set progress value directly with number
+coreProgress('.my-progress', 'Loading...')           // Set indeterminate status using non-numerical string. The same string will be read by screen readers.
+coreProgress('.my-progress', {value: 50, max: 100})  // Set progress value and/or maximum value
 ```
-
-### Possible `value`s
-
-Type | Example | Description
-:-- | :-- | :--
-Integer | `coreProgress(el, 50)` | An integer updates the progress value directly
-String | `coreProgress(el, 'Loading...')` | A non-numerical string will indicate that the progress is indeterminate. The same string will be read by screen readers.
-Object | `coreProgress(el, {value: 50, max: 100})` | An object can define a value and/or a max value
-undefined | `coreProgress(el)` | When no value is passed, the progress element will automatically get pick up values from markup attributes and enhance accessibility.
 
 ### React / Preact
 

--- a/packages/core-progress/readme.md
+++ b/packages/core-progress/readme.md
@@ -86,7 +86,7 @@ coreProgress(
 )
 
 // Examples:
-coreProgress('.my-progress')                         // Initalize tabs on element
+coreProgress('.my-progress')                         // Initalize and ensure accessibility correct attributes
 coreProgress('.my-progress', 1)                      // Set progress value directly with number
 coreProgress('.my-progress', 'Loading...')           // Set indeterminate status using non-numerical string. The same string will be read by screen readers.
 coreProgress('.my-progress', {value: 50, max: 100})  // Set progress value and/or maximum value

--- a/packages/core-scroll/readme.md
+++ b/packages/core-scroll/readme.md
@@ -11,7 +11,7 @@ npm install @nrk/core-scroll --save-exact
 ```
 ```js
 import coreScroll from '@nrk/core-scroll'     // Vanilla JS
-import CoreScroll from '@nrk/core-scroll/jsx' // ...or React/Preact compatible JSX
+import CoreScroll from '@nrk/core-scroll/jsx' // React/Preact JSX
 ```
 
 

--- a/packages/core-tabs/readme.md
+++ b/packages/core-tabs/readme.md
@@ -123,7 +123,7 @@ import CoreTabs from '@nrk/core-tabs/jsx'
 
 // All props are optional, and defaults are shown below
 // Props like className, style, etc. will be applied as actual attributes
-// <Tabs> will handle state itself unless you call event.preventDefault() in onToggle
+// <CoreTabs> will handle state itself unless you call event.preventDefault() in onToggle
 
 <CoreTabs open={0} onToggle={(event) => {}}>
   <div>                     // First element must contain tabs

--- a/packages/core-tabs/readme.md
+++ b/packages/core-tabs/readme.md
@@ -11,7 +11,7 @@ npm install @nrk/core-tabs --save-exact
 ```
 ```js
 import coreTabs from '@nrk/core-tabs'     // Vanilla JS
-import CoreTabs from '@nrk/core-tabs/jsx' // ...or React/Preact compatible JSX
+import CoreTabs from '@nrk/core-tabs/jsx' // React/Preact JSX
 ```
 
 
@@ -87,14 +87,33 @@ demo-->
 
 ## Usage
 
-### JavaScript
+### HTML / JavaScript
+
+```html
+<div class="my-tabs"> <!-- Direct children must be <a> or <button>. Do not use <li> -->
+  <button id="tab-1">Tab 1</button>
+  <button id="tab-2">Tab 2</button>
+  <button id="tab-3">Tab 2</button>
+</div>
+<div> <!-- Next element children will become panels of correlating tab -->
+  <div>Tab 1 content </div>
+  <div hidden>Tab 2 content</div>
+  <div hidden>Tab 3 content</div>
+</div>
+```
+
 ```js
 import coreTabs from '@nrk/core-tabs'
 
 coreTabs(
   String|Element|Elements,    // Accepts a selector string, NodeList, Element or array of Elements
-  open                        // Optional. Can be String: id of tab, Element: tab or Number: index of tab
+  String|Element|Number       // Optional. Set tab selection with string id, element or tab index number
 )
+
+// Examples:
+coreTabs('.my-tabs')              // Initalize tabs on element
+coreTabs('.my-tabs', 3)           // Initalize tabs and select 3rd tab
+coreTabs('.my-tabs', '#tab-2')    // Initalize tabs and select 2nd tab
 ```
 
 ### React / Preact

--- a/packages/core-tabs/readme.md
+++ b/packages/core-tabs/readme.md
@@ -114,6 +114,7 @@ coreTabs(
 coreTabs('.my-tabs')              // Initalize tabs on element
 coreTabs('.my-tabs', 3)           // Initalize tabs and select 3rd tab
 coreTabs('.my-tabs', '#tab-2')    // Initalize tabs and select 2nd tab
+coreTabs('.my-tabs', element)     // Initalize tabs and select tab from element
 ```
 
 ### React / Preact

--- a/packages/core-toggle/readme.md
+++ b/packages/core-toggle/readme.md
@@ -3,6 +3,10 @@
 > `@nrk/core-toggle` simply makes a `<button>` toggle the visibility of next element sibling. Toggles can be nested and easily extended with custom animations or behavior through the [toggle event](#events). It has two modes:
 
 
+<!--demo
+<script src="core-toggle/core-toggle.min.js"></script>
+<script src="core-toggle/core-toggle.jsx.js"></script>
+demo-->
 
 ## Installation
 
@@ -15,31 +19,44 @@ import CoreToggle from '@nrk/core-toggle/jsx' // React/Preact JSX
 ```
 
 
-
 ## Demo
-
-<!--demo
-<script src="core-toggle/core-toggle.min.js"></script>
-<script src="core-toggle/core-toggle.jsx.js"></script>
-demo-->
 
 ```html
 <!--demo-->
-<button class="my-toggle">Toggle VanillaJS</button>  <!-- must be <button> -->
-<div hidden>Content</div>                                       <!-- hidden prevents flash of unstyled content -->
+<button class="my-popup">Popup VanillaJS</button>
+<ul class="my-dropdown" hidden>
+  <li><a>Link</a></li>
+  <li>
+    <button class="my-popup">Can also be nested</button>
+    <ul class="my-dropdown" hidden>
+      <li><a>Sub-link</a></li>
+      <li><input type="text" autofocus aria-label="Skriv her"></li>
+    </ul>
+  </li>
+</ul>
 <script>
-  coreToggle('.my-toggle') // Optionally pass {open: true|false} as second argument to open/close
+  coreToggle('.my-popup', { popup: 'Example picker' })
 </script>
 ```
 
 ```html
 <!--demo-->
-<div id="jsx-toggle-default"></div>
+<div id="jsx-toggle-popup"></div>
 <script type="text/jsx">
-  ReactDOM.render(<CoreToggle popup={false} open={false} onToggle={function(){}}>
-    <button>Toggle JSX</button>
-    <div>Content</div>
-  </CoreToggle>, document.getElementById('jsx-toggle-default'))
+  ReactDOM.render(<CoreToggle popup='Example picker'>
+    <button>Popup JSX</button>
+    <ul className='my-dropdown'>
+      <li><a href='#'>Link</a></li>
+      <li>
+        <CoreToggle popup='Example picker'>
+          <button>Can also be nested</button>
+          <ul className='my-dropdown'>
+            <li><a href='#'>Sub-link</a></li>
+          </ul>
+        </CoreToggle>
+      </li>
+    </ul>
+  </CoreToggle>, document.getElementById('jsx-toggle-popup'))
 </script>
 ```
 
@@ -143,46 +160,26 @@ All styling in documentation is example only. Both the `<button>` and content el
 .my-toggle-content[hidden] {}         /* Target only closed content */
 ```
 
-## Demo: Popup
+## Demo: Expand
 
-Content is toggled when clicking `button`, and closed when clicking outside content. Great for dropdowns and tooltips.
+Content is only toggled when clicking the button. Great for accordions and expand/collapse panels.
 
 ```html
 <!--demo-->
-<button class="my-popup">Popup VanillaJS</button>
-<ul class="my-dropdown" hidden>
-  <li><a>Link</a></li>
-  <li>
-    <button class="my-popup">Can also be nested</button>
-    <ul class="my-dropdown" hidden>
-      <li><a>Sub-link</a></li>
-      <li><input type="text" autofocus aria-label="Skriv her"></li>
-    </ul>
-  </li>
-</ul>
+<button class="my-toggle">Toggle VanillaJS</button>  <!-- must be <button> -->
+<div hidden>Content</div>                                       <!-- hidden prevents flash of unstyled content -->
 <script>
-  coreToggle('.my-popup', { popup: 'Example picker' })
+  coreToggle('.my-toggle') // Optionally pass {open: true|false} as second argument to open/close
 </script>
 ```
-
 ```html
 <!--demo-->
-<div id="jsx-toggle-popup"></div>
+<div id="jsx-toggle-default"></div>
 <script type="text/jsx">
-  ReactDOM.render(<CoreToggle popup='Example picker'>
-    <button>Popup JSX</button>
-    <ul className='my-dropdown'>
-      <li><a href='#'>Link</a></li>
-      <li>
-        <CoreToggle popup='Example picker'>
-          <button>Can also be nested</button>
-          <ul className='my-dropdown'>
-            <li><a href='#'>Sub-link</a></li>
-          </ul>
-        </CoreToggle>
-      </li>
-    </ul>
-  </CoreToggle>, document.getElementById('jsx-toggle-popup'))
+  ReactDOM.render(<CoreToggle popup={false} open={false} onToggle={function(){}}>
+    <button>Toggle JSX</button>
+    <div>Content</div>
+  </CoreToggle>, document.getElementById('jsx-toggle-default'))
 </script>
 ```
 

--- a/packages/core-toggle/readme.md
+++ b/packages/core-toggle/readme.md
@@ -69,7 +69,7 @@ import CoreToggle from '@nrk/core-toggle/jsx'
 
 // All props are optional, and defaults are shown below
 // Props like className, style, etc. will be applied as actual attributes
-// <Toggle> will handle state itself unless you call event.preventDefault() in onToggle
+// <CoreToggle> will handle state itself unless you call event.preventDefault() in onToggle
 
 <CoreToggle open={false} popup={false} onToggle={(event) => {}}>
   <button>Use with JSX</button>  // First element must result in a <button>-tag. Accepts both elements and components

--- a/packages/core-toggle/readme.md
+++ b/packages/core-toggle/readme.md
@@ -11,18 +11,17 @@ npm install @nrk/core-toggle --save-exact
 ```
 ```js
 import coreToggle from '@nrk/core-toggle'     // Vanilla JS
-import CoreToggle from '@nrk/core-toggle/jsx' // ...or React/Preact compatible JSX
+import CoreToggle from '@nrk/core-toggle/jsx' // React/Preact JSX
 ```
 
 
 
-## Demo: Default
+## Demo
 
 <!--demo
 <script src="core-toggle/core-toggle.min.js"></script>
 <script src="core-toggle/core-toggle.jsx.js"></script>
 demo-->
-Content is only toggled when clicking `button`. Great for accordions and expand/collapse panels.
 
 ```html
 <!--demo-->
@@ -42,6 +41,106 @@ Content is only toggled when clicking `button`. Great for accordions and expand/
     <div>Content</div>
   </CoreToggle>, document.getElementById('jsx-toggle-default'))
 </script>
+```
+
+## Usage
+
+### HTML / JavaScript
+
+```html
+<button class="my-toggle">Toggle VanillaJS</button>  <!-- must be <button> -->
+<div hidden>Content</div>                            <!-- use hidden to prevent flash of unstyled content -->
+```
+
+```js
+import coreToggle from '@nrk/core-toggle'
+
+coreToggle(String|Element|Elements, {   // Accepts a selector string, NodeList, Element or array of Elements
+  open: Boolean                         // Optional. Defaults to aria-expanded or false. Set to force open state.
+  popup: Boolean|String                 // Optional. Defaults to false. Enable or disable if clicking outside toggle should close it. Provide a string to control the aria-label text on the toggle.
+  value: String                         // Optional. Defaults to button.innerHTML. Sets innerHTML of the button and safely updates aria-label for screen readers.
+})
+```
+
+### React / Preact
+
+```jsx
+import CoreToggle from '@nrk/core-toggle/jsx'
+
+// All props are optional, and defaults are shown below
+// Props like className, style, etc. will be applied as actual attributes
+// <Toggle> will handle state itself unless you call event.preventDefault() in onToggle
+
+<CoreToggle open={false} popup={false} onToggle={(event) => {}}>
+  <button>Use with JSX</button>  // First element must result in a <button>-tag. Accepts both elements and components
+  <div>Content</div>             // Next element will be toggled. Accepts both elements and components
+</CoreToggle>
+```
+
+## Markup
+
+### With aria-controls
+
+Putting the toggle button directly before the content is highly recommended, as this fulfills all accessibility requirements by default. There might be scenarios though, where styling makes this DOM structure impractical. In such cases, give the toggle button an `aria-controls` attribute, and the content an `id` with corresponding value. Make sure there is no text between the button and toggle content, as this will break the experience for screen reader users:
+
+```html
+<div>
+  <button class="my-toggle" aria-controls="content">Toggle VanillaJS</button>
+</div>
+<div id="content" hidden>Content</div>
+```
+
+### Autofocus
+
+If you have form elements inside a `@nrk/core-toggle`, you can optionally add a `autofocus` attribute to the most prominent form element. This helps the user navigate quickly when toggle is opened.
+
+
+
+
+## Events
+
+### toggle
+
+Before a `@nrk/core-toggle` changes open state, a [toggle event](https://www.w3schools.com/jsref/event_ontoggle.asp) is fired (both for VanillaJS and React/Preact components). The toggle event is cancelable, meaning you can use [`event.preventDefault()`](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault) to cancel toggling. The event also [bubbles](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#Event_bubbling_and_capture), and can therefore be detected both from the button element itself, or any parent element (read [event delegation](https://stackoverflow.com/questions/1687296/what-is-dom-event-delegation)):
+
+
+```js
+document.addEventListener('toggle', (event) => {
+  event.target                              // The button element triggering toggle event
+  event.detail.relatedTarget                // The content element controlled by button
+  event.detail.isOpen                       // The current toggle state (before toggle event has run)
+  event.detail.willOpen                     // The wanted toggle state
+})
+```
+
+### toggle.select
+
+The `toggle.select` event is fired whenever an item is selected inside a toggle with the `popup` option enabled.
+Useful for setting the value of the toggle button with the selected value.
+
+
+```js
+document.addEventListener('toggle.select', (event) => {
+  event.target                              // The buttom element triggering the event
+  event.detail.relatedTarget                // The content element controlled by button
+  event.detail.currentTarget                // The item element selected
+  event.detail.value                        // The selected item's value
+})
+```
+
+
+## Styling
+
+All styling in documentation is example only. Both the `<button>` and content element receive attributes reflecting the current toggle state:
+
+```css
+.my-toggle {}                         /* Target button in any state */
+.my-toggle[aria-expanded="true"] {}   /* Target only open button */
+.my-toggle[aria-expanded="false"] {}  /* Target only closed button */
+
+.my-toggle-content {}                 /* Target content in any state */
+.my-toggle-content:not([hidden]) {}   /* Target only open content */
+.my-toggle-content[hidden] {}         /* Target only closed content */
 ```
 
 ## Demo: Popup
@@ -136,114 +235,6 @@ to create a component that behaves like a `<select>`:
   }
   ReactDOM.render(<MyToggleSelect/>, document.getElementById('jsx-toggle-select'))
 </script>
-```
-
-## Usage
-
-### HTML / JavaScript
-
-```html
-<button class="my-toggle">Toggle VanillaJS</button>
-<div hidden>Content</div>
-```
-
-```js
-import coreToggle from '@nrk/core-toggle'
-
-coreToggle(
-  selector, // Accepts a selector string, NodeList, Element or array of Elements
-  options   // An object. See table below for possible properties
-})
-```
-
-
-Property | Default | Type | Description
-:-- | :-- | :-- | :--
-open | `aria-expanded` or `false` | `null` or `String` | Use `true` or `false` to force open state.
-popup | `false` | `Boolean` or `String` | Enable or disable if clicking outside toggle should close it. Provide a string to control the `aria-label` text on the toggle.
-value | `button.innerHTML` | `String` | Set the `innerHTML` of `<button>` and safely updates `aria-label` for screen readers.
-
-
-### React / Preact
-
-```jsx
-import CoreToggle from '@nrk/core-toggle/jsx'
-
-// All props are optional, and defaults are shown below
-// Props like className, style, etc. will be applied as actual attributes
-// <Toggle> will handle state itself unless you call event.preventDefault() in onToggle
-
-<CoreToggle open={false} popup={false} onToggle={(event) => {}}>
-  <button>Use with JSX</button>  // First element must result in a <button>-tag. Accepts both elements and components
-  <div>Content</div>             // Next element will be toggled. Accepts both elements and components
-</CoreToggle>
-```
-
-
-
-## Markup
-
-### With aria-controls
-
-Putting the toggle button directly before the content is highly recommended, as this fulfills all accessibility requirements by default. There might be scenarios though, where styling makes this DOM structure impractical. In such cases, give the toggle button an `aria-controls` attribute, and the content an `id` with corresponding value. Make sure there is no text between the button and toggle content, as this will break the experience for screen reader users:
-
-```html
-<div>
-  <button class="my-toggle" aria-controls="content">Toggle VanillaJS</button>
-</div>
-<div id="content" hidden>Content</div>
-```
-
-### Autofocus
-
-If you have form elements inside a `@nrk/core-toggle`, you can optionally add a `autofocus` attribute to the most prominent form element. This helps the user navigate quickly when toggle is opened.
-
-
-
-## Events
-
-### toggle
-
-Before a `@nrk/core-toggle` changes open state, a [toggle event](https://www.w3schools.com/jsref/event_ontoggle.asp) is fired (both for VanillaJS and React/Preact components). The toggle event is cancelable, meaning you can use [`event.preventDefault()`](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault) to cancel toggling. The event also [bubbles](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#Event_bubbling_and_capture), and can therefore be detected both from the button element itself, or any parent element (read [event delegation](https://stackoverflow.com/questions/1687296/what-is-dom-event-delegation)):
-
-
-```js
-document.addEventListener('toggle', (event) => {
-  event.target                              // The button element triggering toggle event
-  event.detail.relatedTarget                // The content element controlled by button
-  event.detail.isOpen                       // The current toggle state (before toggle event has run)
-  event.detail.willOpen                     // The wanted toggle state
-})
-```
-
-### toggle.select
-
-The `toggle.select` event is fired whenever an item is selected inside a toggle with the `popup` option enabled.
-Useful for setting the value of the toggle button with the selected value.
-
-
-```js
-document.addEventListener('toggle.select', (event) => {
-  event.target                              // The buttom element triggering the event
-  event.detail.relatedTarget                // The content element controlled by button
-  event.detail.currentTarget                // The item element selected
-  event.detail.value                        // The selected item's value
-})
-```
-
-
-## Styling
-
-All styling in documentation is example only. Both the `<button>` and content element receive attributes reflecting the current toggle state:
-
-```css
-.my-toggle {}                         /* Target button in any state */
-.my-toggle[aria-expanded="true"] {}   /* Target only open button */
-.my-toggle[aria-expanded="false"] {}  /* Target only closed button */
-
-.my-toggle-content {}                 /* Target content in any state */
-.my-toggle-content:not([hidden]) {}   /* Target only open content */
-.my-toggle-content[hidden] {}         /* Target only closed content */
 ```
 
 

--- a/packages/readme.md
+++ b/packages/readme.md
@@ -15,7 +15,7 @@ npm install @nrk/core-toggle --save-exact
 
 ```js
 import coreToggle from '@nrk/core-toggle'     // Vanilla JS
-import CoreToggle from '@nrk/core-toggle/jsx' // ...or React/Preact compatible JSX
+import CoreToggle from '@nrk/core-toggle/jsx' // React/Preact JSX
 ```
 ### Using static
 


### PR DESCRIPTION
* be more consistent.
* remove støy
* add type info on arguments (drop table listing of options and args, it's too verbose)
* add `opener` to `core-dialog` https://github.com/nrkno/core-components/issues/187