### PR TITLE
core-scroll: bug with pointer-events:none

### DIFF
--- a/packages/core-scroll/core-scroll.js
+++ b/packages/core-scroll/core-scroll.js
@@ -122,7 +122,7 @@ function onMousemove (event) {
   DRAG.target.scrollTop = DRAG.scrollY += DRAG.diffY
 
   // Prevent links when we know there has been significant movement
-  if (Math.abs(DRAG.scrollX) > 10 || Math.abs(DRAG.scrollY) > 10) {
+  if (Math.abs(DRAG.diffSumX) > 10 || Math.abs(DRAG.diffSumY) > 10) {
     DRAG.target.style.pointerEvents = 'none'
   }
 }

--- a/packages/core-scroll/core-scroll.js
+++ b/packages/core-scroll/core-scroll.js
@@ -113,6 +113,10 @@ function onMousedown (event) {
   document.addEventListener('mouseup', onMouseup)
 }
 
+function isSignificantDrag() {
+  return Math.abs(DRAG.diffSumX) > 10 || Math.abs(DRAG.diffSumY) > 10;
+}
+
 function onMousemove (event) {
   DRAG.diffX = DRAG.pageX - (DRAG.pageX = event.pageX)
   DRAG.diffY = DRAG.pageY - (DRAG.pageY = event.pageY)
@@ -122,7 +126,7 @@ function onMousemove (event) {
   DRAG.target.scrollTop = DRAG.scrollY += DRAG.diffY
 
   // Prevent links when we know there has been significant movement
-  if (Math.abs(DRAG.diffSumX) > 10 || Math.abs(DRAG.diffSumY) > 10) {
+  if (isSignificantDrag()) {
     DRAG.target.style.pointerEvents = 'none'
   }
 }

--- a/packages/core-scroll/core-scroll.js
+++ b/packages/core-scroll/core-scroll.js
@@ -113,8 +113,8 @@ function onMousedown (event) {
   document.addEventListener('mouseup', onMouseup)
 }
 
-function isSignificantDrag() {
-  return Math.abs(DRAG.diffSumX) > 10 || Math.abs(DRAG.diffSumY) > 10;
+function isSignificantDrag () {
+  return Math.abs(DRAG.diffSumX) > 10 || Math.abs(DRAG.diffSumY) > 10
 }
 
 function onMousemove (event) {

--- a/packages/core-scroll/core-scroll.js
+++ b/packages/core-scroll/core-scroll.js
@@ -100,6 +100,8 @@ function onMousedown (event) {
 
   DRAG.pageX = event.pageX
   DRAG.pageY = event.pageY
+  DRAG.diffSumX = 0
+  DRAG.diffSumY = 0
   DRAG.animate = DRAG.diffX = DRAG.diffY = 0 // Reset
   DRAG.scrollX = this.scrollLeft
   DRAG.scrollY = this.scrollTop
@@ -114,6 +116,8 @@ function onMousedown (event) {
 function onMousemove (event) {
   DRAG.diffX = DRAG.pageX - (DRAG.pageX = event.pageX)
   DRAG.diffY = DRAG.pageY - (DRAG.pageY = event.pageY)
+  DRAG.diffSumX += DRAG.diffX
+  DRAG.diffSumY += DRAG.diffY
   DRAG.target.scrollLeft = DRAG.scrollX += DRAG.diffX
   DRAG.target.scrollTop = DRAG.scrollY += DRAG.diffY
 


### PR DESCRIPTION
### Description
On rewrite to custom element it seems that some logic got lost in translation.

The check around `DRAG.target.style.pointerEvents = 'none'` changed so that `DRAG.diffSumX` was removed and replaced by `DRAG.scrollX` (= `this.scrollLeft`).

That means `pointer-events` is set to `none` at any time when the container is scrolled.
Very apparent with react (synthetic event timing?) on Chrome in Windows where (most) click events are prevented before reaching items inside the scroll container.

### Screenshot
> Have a look at the live expression evaluating pointer-events
![scroll-bug](https://user-images.githubusercontent.com/658586/60240428-3d80df00-98b1-11e9-854d-b161cbd1c96d.gif)

### Details / Context

Before custom element rewrite:

https://github.com/nrkno/core-components/blob/1de460c154122928dd3617e3ba739a21a34b6ad9/packages/core-scroll/core-scroll.js#L94-L104

https://github.com/nrkno/core-components/blob/1de460c154122928dd3617e3ba739a21a34b6ad9/packages/core-scroll/core-scroll.js#L87-L92

After custom element rewrite:

https://github.com/nrkno/core-components/blob/7f80c6d7ad725c832c8b207f67959e3d2c75318f/packages/core-scroll/core-scroll.js#L114-L124

