### PR TITLE
core-dialog: bug with focus when rendering in react portal

### DIFF
--- a/packages/core-dialog/core-dialog.js
+++ b/packages/core-dialog/core-dialog.js
@@ -36,10 +36,11 @@ export default class CoreDialog extends HTMLElement {
         this.backdrop.style.zIndex = zIndex + 1
         active.setAttribute(this._opener, '') // Remember opener element
         setFocus(this)
+        setTimeout(() => setFocus(this)) // Move focus after paint (helps iOS and react portals)
       } else if (opener) {
         opener.focus()
         opener.removeAttribute(this._opener)
-        setTimeout(() => opener.focus()) // Move focus after paint (helps iOS)
+        setTimeout(() => opener.focus()) // Move focus after paint (helps iOS and react portals)
       }
 
       if (force !== true) dispatchEvent(this, 'dialog.toggle')


### PR DESCRIPTION
Reuse trick with `setTimeout` on focusing opener seems to solve issue with setting focus to first focusable element when rendering dialog inside react portal.

Before | After
-- | --
![focusl-bug-example-after](https://user-images.githubusercontent.com/658586/60585073-24839c80-9d8f-11e9-8565-3994f91508fb.gif) | ![focusl-bug-example](https://user-images.githubusercontent.com/658586/60585066-2188ac00-9d8f-11e9-80e8-165d7d421a6b.gif)


