### PR TITLE
Datepicker JSX, i18n

### DIFF
--- a/packages/core-datepicker/core-datepicker.js
+++ b/packages/core-datepicker/core-datepicker.js
@@ -73,8 +73,8 @@ export default class CoreDatepicker extends HTMLElement {
 }
 
 const pad = (val) => `0${val}`.slice(-2)
-const forEach = (css, self, fn, force) => [].forEach.call(document.getElementsByTagName(css), (el) => {
-  if (self.contains(el) || self.id === el.getAttribute(self.external)) fn(self, el, force)
+const forEach = (css, self, fn, ...args) => [].forEach.call(document.getElementsByTagName(css), (el) => {
+  if (self.contains(el) || self.id === el.getAttribute(self.external)) fn(self, el, ...args)
 })
 
 function button (self, el) {

--- a/packages/core-datepicker/core-datepicker.js
+++ b/packages/core-datepicker/core-datepicker.js
@@ -18,7 +18,7 @@ export default class CoreDatepicker extends HTMLElement {
     addStyle(this.nodeName, `${this.nodeName}{display:block}`) //  default to display block
   }
   disconnectedCallback () {
-    this._date = this._disabled = null // Garbage collection
+    this._date = this._disabled = this._select = null // Garbage collection
     document.removeEventListener('click', this)
     document.removeEventListener('change', this)
     document.removeEventListener('keydown', this)

--- a/packages/core-datepicker/core-datepicker.js
+++ b/packages/core-datepicker/core-datepicker.js
@@ -10,7 +10,7 @@ export default class CoreDatepicker extends HTMLElement {
   static get observedAttributes () { return ['timestamp', 'months', 'days'] }
 
   connectedCallback () {
-    this._selects = this._selects || [];
+    this._selects = this._selects || []
     this._date = this.date // Store for later comparison and speeding up things
     document.addEventListener('click', this)
     document.addEventListener('change', this)

--- a/packages/core-datepicker/core-datepicker.js
+++ b/packages/core-datepicker/core-datepicker.js
@@ -18,7 +18,7 @@ export default class CoreDatepicker extends HTMLElement {
     addStyle(this.nodeName, `${this.nodeName}{display:block}`) //  default to display block
   }
   disconnectedCallback () {
-    this._date = this._disabled = this._select = null // Garbage collection
+    this._date = this._disabled = null // Garbage collection
     document.removeEventListener('click', this)
     document.removeEventListener('change', this)
     document.removeEventListener('keydown', this)

--- a/packages/core-datepicker/core-datepicker.js
+++ b/packages/core-datepicker/core-datepicker.js
@@ -96,11 +96,9 @@ function input (self, el) {
 }
 
 function table (self, table) {
-  if (!table.firstElementChild) {
-    table.innerHTML = `
-    <caption></caption><thead><tr><th>${self.days.map(escapeHTML).join('</th><th>')}</th></tr></thead>
-    <tbody>${Array(7).join(`<tr>${Array(8).join('<td><button type="button"></button></td>')}</tr>`)}</tbody>`
-  }
+  table.innerHTML = `
+  <caption></caption><thead><tr><th>${self.days.map(escapeHTML).join('</th><th>')}</th></tr></thead>
+  <tbody>${Array(7).join(`<tr>${Array(8).join('<td><button type="button"></button></td>')}</tr>`)}</tbody>`
 
   const today = new Date()
   const month = self.date.getMonth()
@@ -126,6 +124,9 @@ function table (self, table) {
 
 function select (self, select) {
   if (!select.firstElementChild) {
+    self._select = select;
+  }
+  if (self._select) {
     select.innerHTML = self.months.map((name, month) =>
       `<option value="y-${month + 1}-d">${escapeHTML(name)}</option>`
     ).join('')

--- a/packages/core-datepicker/core-datepicker.js
+++ b/packages/core-datepicker/core-datepicker.js
@@ -10,6 +10,7 @@ export default class CoreDatepicker extends HTMLElement {
   static get observedAttributes () { return ['timestamp', 'months', 'days'] }
 
   connectedCallback () {
+    this._selects = this._selects || [];
     this._date = this.date // Store for later comparison and speeding up things
     document.addEventListener('click', this)
     document.addEventListener('change', this)
@@ -19,6 +20,7 @@ export default class CoreDatepicker extends HTMLElement {
   }
   disconnectedCallback () {
     this._date = this._disabled = null // Garbage collection
+    this._selects = [] // Garbage collection
     document.removeEventListener('click', this)
     document.removeEventListener('change', this)
     document.removeEventListener('keydown', this)
@@ -125,7 +127,10 @@ function table (self, table, force) {
 }
 
 function select (self, select, force) {
-  if (!select.firstElementChild || force) {
+  if (!select.firstElementChild) {
+    self._selects = [...self._selects || [], select]
+  }
+  if (!select.firstElementChild || (force && self._selects.indexOf(select) > 0)) {
     select.innerHTML = self.months.map((name, month) =>
       `<option value="y-${month + 1}-d">${escapeHTML(name)}</option>`
     ).join('')

--- a/packages/core-datepicker/core-datepicker.js
+++ b/packages/core-datepicker/core-datepicker.js
@@ -1,4 +1,4 @@
-import { addStyle, closest, escapeHTML, dispatchEvent, queryAll } from '../utils'
+import { addStyle, closest, dispatchEvent, queryAll } from '../utils'
 import parse from '@nrk/simple-date-parse'
 
 const MASK = { year: '*-m-d', month: 'y-*-d', day: 'y-m-*', hour: '*:m', minute: 'h:*', second: 'h:m:*', timestamp: '*', null: '*' }
@@ -10,7 +10,6 @@ export default class CoreDatepicker extends HTMLElement {
   static get observedAttributes () { return ['timestamp', 'months', 'days'] }
 
   connectedCallback () {
-    this._selects = this._selects || [] // Controlled select elements
     this._date = this.date // Store for later comparison and speeding up things
     document.addEventListener('click', this)
     document.addEventListener('change', this)
@@ -18,23 +17,25 @@ export default class CoreDatepicker extends HTMLElement {
     setTimeout(() => this.attributeChangedCallback()) // Render after children is parsed
     addStyle(this.nodeName, `${this.nodeName}{display:block}`) //  default to display block
   }
+
   disconnectedCallback () {
     this._date = this._disabled = null // Garbage collection
-    this._selects = [] // Garbage collection
     document.removeEventListener('click', this)
     document.removeEventListener('change', this)
     document.removeEventListener('keydown', this)
   }
+
   attributeChangedCallback (name) {
     if (!this._date) return // Only render after connectedCallback
     if (this.disabled(this.date) && !this.disabled(this._date)) return (this.date = this._date) // Jump back
     if (this.diff(this.date)) dispatchEvent(this, 'datepicker.change', this._date = this.date)
 
     forEach('button', this, button)
-    forEach('select', this, select, name === 'months')
+    forEach('select', this, select)
     forEach('input', this, input)
-    forEach('table', this, table, name === 'days')
+    forEach('table', this, table)
   }
+
   handleEvent (event) {
     if (event.defaultPrevented || event.ctrlKey || event.metaKey || event.shiftKey || event.altKey || (event.type === 'keydown' && !KEYS[event.keyCode])) return
     if (!this.contains(event.target) && !closest(event.target, `[for="${this.id}"]`)) return
@@ -50,36 +51,52 @@ export default class CoreDatepicker extends HTMLElement {
       event.preventDefault() // Prevent scrolling
     }
   }
+
   diff (val) { return this.parse(val).getTime() - this.timestamp }
+
   parse (val, from) { return parse(val, from || this._date) }
 
   get disabled () { return this._disabled || Function.prototype }
+
   set disabled (fn) {
     this._disabled = typeof fn === 'function' ? (val) => fn(this.parse(val), this) : () => fn // Auto parse dates
     this.attributeChangedCallback() // Re-render
   }
 
   get timestamp () { return String(this._date.getTime()) }
+
   get year () { return String(this._date.getFullYear()) } // Stringify for consistency and for truthy '0'
+
   get month () { return pad(this._date.getMonth() + 1) }
+
   get day () { return pad(this._date.getDate()) }
+
   get hour () { return pad(this._date.getHours()) }
+
   get minute () { return pad(this._date.getMinutes()) }
+
   get second () { return pad(this._date.getSeconds()) }
+
   get date () { return parse(this.getAttribute('timestamp') || this._date || Date.now()) }
+
   set date (val) { return this.setAttribute('timestamp', this.parse(val).getTime()) }
+
   set months (val) { this.setAttribute('months', [].concat(val).join(',')) }
+
   get months () { return (this.getAttribute('months') || MONTHS).split(/\s*,\s*/) }
+
   set days (val) { this.setAttribute('days', [].concat(val).join(',')) }
+
   get days () { return (this.getAttribute('days') || DAYS).split(/\s*,\s*/) }
 }
 
 const pad = (val) => `0${val}`.slice(-2)
-const forEach = (css, self, fn, ...args) => [].forEach.call(document.getElementsByTagName(css), (el) => {
-  if (self.contains(el) || self.id === el.getAttribute(self.external)) fn(self, el, ...args)
+const forEach = (css, self, fn) => [].forEach.call(document.getElementsByTagName(css), (el) => {
+  if (self.contains(el) || self.id === el.getAttribute(self.external)) fn(self, el)
 })
 
 function button (self, el) {
+  if (!el.value) return // Skip buttons without a set value
   el.type = 'button' // Ensure forms are not submitted by datepicker-buttons
   el.disabled = self.disabled(el.value)
 }
@@ -97,10 +114,10 @@ function input (self, el) {
   }
 }
 
-function table (self, table, force) {
-  if (!table.firstElementChild || force) {
+function table (self, table) {
+  if (!table.firstElementChild) {
     table.innerHTML = `
-    <caption></caption><thead><tr><th>${self.days.map(escapeHTML).join('</th><th>')}</th></tr></thead>
+    <caption></caption><thead><tr><th>${Array(8).join('</th><th>')}</th></tr></thead>
     <tbody>${Array(7).join(`<tr>${Array(8).join('<td><button type="button"></button></td>')}</tr>`)}</tbody>`
   }
 
@@ -109,6 +126,7 @@ function table (self, table, force) {
   const day = self.parse('y-m-1 mon') // Monday in first week of month
   table.caption.textContent = `${self.months[month]}, ${self.year}`
 
+  queryAll('th', table).forEach((th, day) => (th.textContent = self.days[day]))
   queryAll('button', table).forEach((button) => {
     const isSelected = !self.diff(day)
     const dayInMonth = day.getDate()
@@ -126,17 +144,15 @@ function table (self, table, force) {
   })
 }
 
-function select (self, select, force) {
+function select (self, select) {
   if (!select.firstElementChild) {
-    self._selects = [...self._selects || [], select]
-  }
-  if (!select.firstElementChild || (force && self._selects.indexOf(select) >= 0)) {
     select.innerHTML = self.months.map((name, month) =>
-      `<option value="y-${month + 1}-d">${escapeHTML(name)}</option>`
+      `<option value="y-${month + 1}-d"></option>`
     ).join('')
   }
 
-  queryAll(select.children).forEach((option) => {
+  queryAll(select.children).forEach((option, month) => {
+    option.textContent = self.months[month]
     option.disabled = self.disabled(option.value)
     option.selected = !self.diff(option.value)
   })

--- a/packages/core-datepicker/core-datepicker.js
+++ b/packages/core-datepicker/core-datepicker.js
@@ -117,7 +117,7 @@ function input (self, el) {
 function table (self, table) {
   if (!table.firstElementChild) {
     table.innerHTML = `
-    <caption></caption><thead><tr><th>${Array(8).join('</th><th>')}</th></tr></thead>
+    <caption></caption><thead><tr>${Array(8).join('</th><th>')}</tr></thead>
     <tbody>${Array(7).join(`<tr>${Array(8).join('<td><button type="button"></button></td>')}</tr>`)}</tbody>`
   }
 
@@ -146,13 +146,14 @@ function table (self, table) {
 
 function select (self, select) {
   if (!select.firstElementChild) {
+    select._autofill = true
     select.innerHTML = self.months.map((name, month) =>
       `<option value="y-${month + 1}-d"></option>`
     ).join('')
   }
 
   queryAll(select.children).forEach((option, month) => {
-    option.textContent = self.months[month]
+    if (select._autofill) option.textContent = self.months[month]
     option.disabled = self.disabled(option.value)
     option.selected = !self.diff(option.value)
   })

--- a/packages/core-datepicker/core-datepicker.js
+++ b/packages/core-datepicker/core-datepicker.js
@@ -25,7 +25,7 @@ export default class CoreDatepicker extends HTMLElement {
     document.removeEventListener('keydown', this)
   }
 
-  attributeChangedCallback (name) {
+  attributeChangedCallback () {
     if (!this._date) return // Only render after connectedCallback
     if (this.disabled(this.date) && !this.disabled(this._date)) return (this.date = this._date) // Jump back
     if (this.diff(this.date)) dispatchEvent(this, 'datepicker.change', this._date = this.date)

--- a/packages/core-datepicker/core-datepicker.js
+++ b/packages/core-datepicker/core-datepicker.js
@@ -124,7 +124,7 @@ function table (self, table) {
 
 function select (self, select) {
   if (!select.firstElementChild) {
-    self._select = select;
+    self._select = select
   }
   if (self._select) {
     select.innerHTML = self.months.map((name, month) =>

--- a/packages/core-datepicker/core-datepicker.js
+++ b/packages/core-datepicker/core-datepicker.js
@@ -130,7 +130,7 @@ function select (self, select, force) {
   if (!select.firstElementChild) {
     self._selects = [...self._selects || [], select]
   }
-  if (!select.firstElementChild || (force && self._selects.indexOf(select) > 0)) {
+  if (!select.firstElementChild || (force && self._selects.indexOf(select) >= 0)) {
     select.innerHTML = self.months.map((name, month) =>
       `<option value="y-${month + 1}-d">${escapeHTML(name)}</option>`
     ).join('')

--- a/packages/core-datepicker/core-datepicker.js
+++ b/packages/core-datepicker/core-datepicker.js
@@ -10,7 +10,7 @@ export default class CoreDatepicker extends HTMLElement {
   static get observedAttributes () { return ['timestamp', 'months', 'days'] }
 
   connectedCallback () {
-    this._selects = this._selects || []
+    this._selects = this._selects || [] // Controlled select elements
     this._date = this.date // Store for later comparison and speeding up things
     document.addEventListener('click', this)
     document.addEventListener('change', this)

--- a/packages/core-datepicker/core-datepicker.jsx
+++ b/packages/core-datepicker/core-datepicker.jsx
@@ -3,7 +3,7 @@ import { version } from './package.json'
 import customElementToReact from '@nrk/custom-element-to-react'
 
 export default customElementToReact(CoreDatepicker, {
-  props: ['disabled', 'months', 'days'],
+  props: ['disabled'],
   customEvents: ['datepicker.change', 'datepicker.click.day'],
   suffix: version
 })

--- a/packages/core-datepicker/readme.md
+++ b/packages/core-datepicker/readme.md
@@ -119,7 +119,7 @@ demo-->
     constructor (props) {
       super(props)
       this.today = Date.now() - Date.now() % 864e3
-      this.state = { date: new Date(), odd: true }
+      this.state = { date: new Date() }
       this.onNow = this.onNow.bind(this)
       this.onChange = this.onChange.bind(this)
     }
@@ -140,42 +140,6 @@ demo-->
         </CoreToggle>
         <button onClick={this.onNow}>I dag JSX</button>
         <input type="text" readOnly value={this.state.date.toLocaleDateString()} />
-        <br />
-        <button>Choose date JSX</button>
-        <CoreToggle hidden popup className="my-popup">
-          <CoreDatepicker
-            timestamp={this.state.date.getTime()}
-            disabled={(date) => date <= this.today}
-            months={[
-                "January",
-                "February",
-                "March",
-                "April",
-                "May",
-                "June",
-                "July",
-                "August",
-                "September",
-                "October",
-                "November",
-                "December"
-            ]}
-            days={[
-                "Mon",
-                "Tue",
-                "Wed",
-                "Thu",
-                "Fri",
-                "Sat",
-                "Sun"
-            ]}
-            onDatepickerChange={this.onChange}>
-              <button type="button" onClick={() => console.log(this.state) || this.setState({ odd: !this.state.odd })}>Toggle</button>
-              <label>Year<input type="year" /></label>
-              <label>Month<select></select></label>
-              <table></table>
-          </CoreDatepicker>
-        </CoreToggle>
       </div>
     }
   }

--- a/packages/core-datepicker/readme.md
+++ b/packages/core-datepicker/readme.md
@@ -119,7 +119,7 @@ demo-->
     constructor (props) {
       super(props)
       this.today = Date.now() - Date.now() % 864e3
-      this.state = { date: new Date() }
+      this.state = { date: new Date(), odd: true }
       this.onNow = this.onNow.bind(this)
       this.onChange = this.onChange.bind(this)
     }
@@ -140,6 +140,42 @@ demo-->
         </CoreToggle>
         <button onClick={this.onNow}>I dag JSX</button>
         <input type="text" readOnly value={this.state.date.toLocaleDateString()} />
+        <br />
+        <button>Choose date JSX</button>
+        <CoreToggle hidden popup className="my-popup">
+          <CoreDatepicker
+            timestamp={this.state.date.getTime()}
+            disabled={(date) => date <= this.today}
+            months={[
+                "January",
+                "February",
+                "March",
+                "April",
+                "May",
+                "June",
+                "July",
+                "August",
+                "September",
+                "October",
+                "November",
+                "December"
+            ]}
+            days={[
+                "Mon",
+                "Tue",
+                "Wed",
+                "Thu",
+                "Fri",
+                "Sat",
+                "Sun"
+            ]}
+            onDatepickerChange={this.onChange}>
+              <button type="button" onClick={() => console.log(this.state) || this.setState({ odd: !this.state.odd })}>Toggle</button>
+              <label>Year<input type="year" /></label>
+              <label>Month<select></select></label>
+              <table></table>
+          </CoreDatepicker>
+        </CoreToggle>
       </div>
     }
   }


### PR DESCRIPTION
when attributeChangedCallback is triggered by jsx, the select and table already has content which prevents updates. By removing that check we update the DOM on attribute changes.

It should possibly only update DOM when the "months" and "days" attributes changes, but I do not immediately see any huge issue with naively updating the DOM on all attribute changes, they do not update very often.

I have no idea if this is good enough though. Should possibly have a test.

@htor or @eirikbacker, can you make it production-ready and release? :)

### aside
We should revisit the props skip-logic in [custom-element-to-react](https://github.com/nrkno/custom-element-to-react/blob/2b7d3c1d91c65850a1de25d2ce13d22df19c27ec/lib/index.js#L60-L68), as I do believe string properties on custom-elements is supported by react. This will mitigate a possible double rendering issue.


fixes #314