### PR TITLE
suggest ajax error event

### DIFF
--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -159,7 +159,7 @@ function onAjax (self) {
   if (!self.ajax) return
   clearTimeout(self._xhrTime) // Clear previous search
   self._xhr.abort() // Abort previous request
-  self._xhr.error = null
+  self._xhr.responseError = null
   self._xhrTime = setTimeout(onAjaxSend, AJAX_DEBOUNCE, self) // Debounce
   return true
 }
@@ -168,7 +168,7 @@ function onAjaxSend (self) {
   if (!self.input.value) return // Abort if input is empty
   if (dispatchEvent(self, 'suggest.ajax.beforeSend', self._xhr)) {
     self._xhr.onerror = (error) => {
-      self._xhr.error = error.toString()
+      self._xhr.responseError = error.toString()
       dispatchEvent(self, 'suggest.ajax.error', self._xhr)
     }
     self._xhr.onload = () => {
@@ -177,7 +177,7 @@ function onAjaxSend (self) {
         self._xhr.responseJSON = JSON.parse(self._xhr.responseText)
       } catch (error) {
         self._xhr.responseJSON = false
-        self._xhr.error = error.toString()
+        self._xhr.responseError = error.toString()
         dispatchEvent(self, 'suggest.ajax.error', self._xhr)
       }
       dispatchEvent(self, 'suggest.ajax', self._xhr)

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -159,7 +159,7 @@ function onAjax (self) {
   if (!self.ajax) return
   clearTimeout(self._xhrTime) // Clear previous search
   self._xhr.abort() // Abort previous request
-  self._xhr.responseError = null
+  self._xhr.error = null
   self._xhrTime = setTimeout(onAjaxSend, AJAX_DEBOUNCE, self) // Debounce
   return true
 }
@@ -167,14 +167,17 @@ function onAjax (self) {
 function onAjaxSend (self) {
   if (!self.input.value) return // Abort if input is empty
   if (dispatchEvent(self, 'suggest.ajax.beforeSend', self._xhr)) {
-    self._xhr.onerror = () => dispatchEvent(self, 'suggest.ajax.error', self._xhr)
+    self._xhr.onerror = (error) => {
+      self._xhr.error = error.toString()
+      dispatchEvent(self, 'suggest.ajax.error', self._xhr)
+    }
     self._xhr.onload = () => {
       if (self._xhr.status !== 200) return dispatchEvent(self, 'suggest.ajax.error', self._xhr)
       try {
         self._xhr.responseJSON = JSON.parse(self._xhr.responseText)
-      } catch (err) {
+      } catch (error) {
         self._xhr.responseJSON = false
-        self._xhr.responseError = err.toString()
+        self._xhr.error = error.toString()
         dispatchEvent(self, 'suggest.ajax.error', self._xhr)
       }
       dispatchEvent(self, 'suggest.ajax', self._xhr)

--- a/packages/core-suggest/core-suggest.jsx
+++ b/packages/core-suggest/core-suggest.jsx
@@ -3,6 +3,6 @@ import { version } from './package.json'
 import customElementToReact from '@nrk/custom-element-to-react'
 
 export default customElementToReact(CoreSuggest, {
-  customEvents: ['suggest.filter', 'suggest.select', 'suggest.ajax', 'suggest.ajax.beforeSend'],
+  customEvents: ['suggest.filter', 'suggest.select', 'suggest.ajax', 'suggest.ajax.beforeSend', 'suggest.ajax.error'],
   suffix: version
 })

--- a/packages/core-suggest/core-suggest.test.js
+++ b/packages/core-suggest/core-suggest.test.js
@@ -126,7 +126,7 @@ test('triggers ajax error on bad url', withPage, async (t, page) => {
     <core-suggest ajax="https://foo" hidden></core-suggest>
   `)
   await page.evaluate(() => {
-    document.addEventListener('suggest.ajax.error', () => window.dispatched = true)
+    document.addEventListener('suggest.ajax.error', () => (window.dispatched = true))
   })
   await page.type('input', 'abc')
   await page.waitForFunction('window.dispatched === true')
@@ -138,10 +138,10 @@ test('triggers ajax error on bad status', withPage, async (t, page) => {
     <input type="text">
     <core-suggest ajax="http://bad-status" hidden></core-suggest>
   `)
-  await page.setRequestInterception(true);
+  await page.setRequestInterception(true)
   page.on('request', (request) => request.respond({ status: 404 }))
   await page.evaluate(() => {
-    document.addEventListener('suggest.ajax.error', () => window.dispatched = true)
+    document.addEventListener('suggest.ajax.error', () => (window.dispatched = true))
   })
   await page.type('input', 'abc')
   await page.waitForFunction('window.dispatched === true')
@@ -153,10 +153,10 @@ test('triggers ajax error on bad json', withPage, async (t, page) => {
     <input type="text">
     <core-suggest ajax="http://bad-json" hidden></core-suggest>
   `)
-  await page.setRequestInterception(true);
+  await page.setRequestInterception(true)
   page.on('request', (request) => request.respond({ body: 'not json' }))
   await page.evaluate(() => {
-    document.addEventListener('suggest.ajax.error', () => window.dispatched = true)
+    document.addEventListener('suggest.ajax.error', () => (window.dispatched = true))
   })
   await page.type('input', 'abc')
   await page.waitForFunction('window.dispatched === true')

--- a/packages/core-suggest/core-suggest.test.js
+++ b/packages/core-suggest/core-suggest.test.js
@@ -119,3 +119,46 @@ test('filters suggestions from limit option', withPage, async (t, page) => {
   t.false(await page.$eval('li:nth-child(3) button', el => el.hasAttribute('hidden')))
   t.true(await page.$eval('li:nth-child(4) button', el => el.hasAttribute('hidden')))
 })
+
+test('triggers ajax error on bad url', withPage, async (t, page) => {
+  await page.setContent(`
+    <input type="text">
+    <core-suggest ajax="https://foo" hidden></core-suggest>
+  `)
+  await page.evaluate(() => {
+    document.addEventListener('suggest.ajax.error', () => window.dispatched = true)
+  })
+  await page.type('input', 'abc')
+  await page.waitForFunction('window.dispatched === true')
+  t.pass()
+})
+
+test('triggers ajax error on bad status', withPage, async (t, page) => {
+  await page.setContent(`
+    <input type="text">
+    <core-suggest ajax="http://bad-status" hidden></core-suggest>
+  `)
+  await page.setRequestInterception(true);
+  page.on('request', (request) => request.respond({ status: 404 }))
+  await page.evaluate(() => {
+    document.addEventListener('suggest.ajax.error', () => window.dispatched = true)
+  })
+  await page.type('input', 'abc')
+  await page.waitForFunction('window.dispatched === true')
+  t.pass()
+})
+
+test('triggers ajax error on bad json', withPage, async (t, page) => {
+  await page.setContent(`
+    <input type="text">
+    <core-suggest ajax="http://bad-json" hidden></core-suggest>
+  `)
+  await page.setRequestInterception(true);
+  page.on('request', (request) => request.respond({ body: 'not json' }))
+  await page.evaluate(() => {
+    document.addEventListener('suggest.ajax.error', () => window.dispatched = true)
+  })
+  await page.type('input', 'abc')
+  await page.waitForFunction('window.dispatched === true')
+  t.pass()
+})

--- a/packages/core-suggest/readme.md
+++ b/packages/core-suggest/readme.md
@@ -212,7 +212,8 @@ document.addEventListener('suggest.ajax', (event) => {
 ```
 
 ### suggest.ajax.error
-Fired when the request fails either due to a bad request (bad URL, non-200 status code) or a bad JSON response body:
+Fired when the request fails either due to a bad request (bad URL, non-200 response) or an
+XHR error or a JSON parse error:
 
 ```js
 document.addEventListener('suggest.ajax.error', (event) => {
@@ -220,7 +221,7 @@ document.addEventListener('suggest.ajax.error', (event) => {
   event.detail  // The XMLHttpRequest object
   event.detail.status         // The response status code
   event.detail.statusText     // The response status text
-  event.detail.responseError  // The response status error
+  event.detail.error          // The error message (XHR)
 })
 ```
 
@@ -228,10 +229,10 @@ document.addEventListener('suggest.ajax.error', (event) => {
 // Example
 document.addEventListener('suggest.ajax.error', (event) => {
   const xhr = event.detail
-  if (xhr.status !== 200) {
-    // Bad request
-  } else if (xhr.responseError) {
-    // Bad JSON
+  if (xhr.status !== 200) {     // Bad request
+    console.log(xhr.statusText) // Log status text
+  } else if (xhr.error) {       // Other error (XHR error/JSON parse error)
+    console.log(xhr.error)      // Log error message
   }
 })
 ```

--- a/packages/core-suggest/readme.md
+++ b/packages/core-suggest/readme.md
@@ -129,6 +129,7 @@ import CoreSuggest from '@nrk/core-suggest/jsx'
              onSuggestFilter={Function}           // See 'suggest.filter' event
              onSuggestSelect={Function}           // See 'suggest.select' event
              onSuggestAjax={Function}             // See 'suggest.ajax' event
+             onSuggestAjaxError={Function}        // See 'suggest.ajax.error' event
              onSuggestAjaxBeforeSend={Function}>  // See 'suggest.ajax.beforeSend' event
   <ul>                    // Next element will be used for items. Accepts both elements and components
     <li><button>Item 1</button></li>                  // Interactive items must be <button> or <a>
@@ -208,6 +209,19 @@ document.addEventListener('suggest.ajax', (event) => {
   event.detail.responseJSON  // The response json. Defaults to false if no valid JSON found
 })
 ```
+
+### suggest.ajax.error
+Fired when the request fails either due to a bad URL, non-200 status or a bad JSON response body:
+
+```js
+document.addEventListener('suggest.ajax.error', (event) => {
+  event.target  // The core-suggest element triggering suggest.ajax event
+  event.detail  // The ajax request
+  event.detail.status       // The response status code
+  event.detail.statusText   // The response status text
+})
+```
+
 
 ## Styling
 All styling in documentation is example only. Both the `<button>` and content element receive attributes reflecting the current toggle state:

--- a/packages/core-suggest/readme.md
+++ b/packages/core-suggest/readme.md
@@ -182,7 +182,7 @@ Fired before sending debounced ajax requests. If you wish to alter the [XMLHttpR
 
 ```js
 document.addEventListener('suggest.ajax.beforeSend', (event) => {
-  event.target  // The core-suggest element triggering suggest.ajax.beforeSend event
+  event.target  // The core-suggest element
   event.detail  // The XMLHttpRequest object
 })
 ```
@@ -190,11 +190,12 @@ document.addEventListener('suggest.ajax.beforeSend', (event) => {
 ```js
 // Example
 document.addEventListener('suggest.ajax.beforeSend', (event) => {
+  const xhr = event.detail
   event.preventDefault() // Stop default behaviour
-  event.detail.open('POST', 'https://example.com')
-  event.detail.setRequestHeader('Content-Type', 'application/json')
-  event.detail.setRequestHeader('my-custom-header', 'my-custom-value')
-  event.detail.send(JSON.stringify({query: event.target.value}))
+  xhr.open('POST', 'https://example.com')
+  xhr.setRequestHeader('Content-Type', 'application/json')
+  xhr.setRequestHeader('my-custom-header', 'my-custom-value')
+  xhr.send(JSON.stringify({query: event.target.value}))
 })
 ```
 
@@ -203,22 +204,35 @@ Fired when the input field receives data from ajax:
 
 ```js
 document.addEventListener('suggest.ajax', (event) => {
-  event.target  // The core-suggest element triggering suggest.ajax event
-  event.detail  // The ajax request
+  event.target  // The core-suggest element
+  event.detail  // The XMLHttpRequest object
   event.detail.responseText  // The response body text
   event.detail.responseJSON  // The response json. Defaults to false if no valid JSON found
 })
 ```
 
 ### suggest.ajax.error
-Fired when the request fails either due to a bad URL, non-200 status or a bad JSON response body:
+Fired when the request fails either due to a bad request (bad URL, non-200 status code) or a bad JSON response body:
 
 ```js
 document.addEventListener('suggest.ajax.error', (event) => {
-  event.target  // The core-suggest element triggering suggest.ajax event
-  event.detail  // The ajax request
-  event.detail.status       // The response status code
-  event.detail.statusText   // The response status text
+  event.target  // The core-suggest element
+  event.detail  // The XMLHttpRequest object
+  event.detail.status         // The response status code
+  event.detail.statusText     // The response status text
+  event.detail.responseError  // The response status error
+})
+```
+
+```js
+// Example
+document.addEventListener('suggest.ajax.error', (event) => {
+  const xhr = event.detail
+  if (xhr.status !== 200) {
+    // Bad request
+  } else if (xhr.responseError) {
+    // Bad JSON
+  }
 })
 ```
 

--- a/packages/core-suggest/readme.md
+++ b/packages/core-suggest/readme.md
@@ -212,8 +212,7 @@ document.addEventListener('suggest.ajax', (event) => {
 ```
 
 ### suggest.ajax.error
-Fired when the request fails either due to a bad request (bad URL, non-200 response) or an
-XHR error or a JSON parse error:
+Fired when the request fails either due to a bad request (bad URL, non-200 response), an AJAX error or a JSON parse error. Inspect `xhr.status` and `xhr.statusText` for bad requests and `xhr.responseError` for other errors:
 
 ```js
 document.addEventListener('suggest.ajax.error', (event) => {
@@ -221,7 +220,7 @@ document.addEventListener('suggest.ajax.error', (event) => {
   event.detail  // The XMLHttpRequest object
   event.detail.status         // The response status code
   event.detail.statusText     // The response status text
-  event.detail.error          // The error message for XHR errors/JSON parse errors
+  event.detail.responseError  // The error message for ajax errors/json parse errors
 })
 ```
 
@@ -229,10 +228,10 @@ document.addEventListener('suggest.ajax.error', (event) => {
 // Example
 document.addEventListener('suggest.ajax.error', (event) => {
   const xhr = event.detail
-  if (xhr.status !== 200) {     // Bad request
-    console.log(xhr.statusText) // Log status text
-  } else if (xhr.error) {       // Other error (XHR error/JSON parse error)
-    console.log(xhr.error)      // Log error message
+  if (xhr.status !== 200) {             // Bad request
+    console.log(xhr.statusText)         // Log status text
+  } else if (xhr.responseError) {       // Other error (ajax error/json parse error)
+    console.log(xhr.responseError)      // Log error message
   }
 })
 ```

--- a/packages/core-suggest/readme.md
+++ b/packages/core-suggest/readme.md
@@ -221,7 +221,7 @@ document.addEventListener('suggest.ajax.error', (event) => {
   event.detail  // The XMLHttpRequest object
   event.detail.status         // The response status code
   event.detail.statusText     // The response status text
-  event.detail.error          // The error message (XHR)
+  event.detail.error          // The error message for XHR errors/JSON parse errors
 })
 ```
 


### PR DESCRIPTION
adds a new event `suggest.ajax.error` to core-suggest for better error handling. 
handles three cases:
* bad urls
* bad statuses (non-200)
* bad json responses

 not sure how to handle timeouts, though?

resolves #295 