### PR TITLE
Toggle and focus refinements

### DIFF
--- a/packages/core-dialog/readme.md
+++ b/packages/core-dialog/readme.md
@@ -109,6 +109,8 @@ demo-->
       this.state = { hidden: true }
       this.toggleDialog = this.toggleDialog.bind(this)
       this.handleToggle = this.handleToggle.bind(this)
+      document.getElementById('jsx-dialog').addEventListener('dialog.toggle', console.log)
+      document.addEventListener('keydown', (e) => e.keyCode === 68 && this.setState({ remove: true }))
     }
 
     toggleDialog () {

--- a/packages/core-dialog/readme.md
+++ b/packages/core-dialog/readme.md
@@ -109,8 +109,6 @@ demo-->
       this.state = { hidden: true }
       this.toggleDialog = this.toggleDialog.bind(this)
       this.handleToggle = this.handleToggle.bind(this)
-      document.getElementById('jsx-dialog').addEventListener('dialog.toggle', console.log)
-      document.addEventListener('keydown', (e) => e.keyCode === 68 && this.setState({ remove: true }))
     }
 
     toggleDialog () {


### PR DESCRIPTION
- Prevent trigger happy focus restoration
- Prevent falsy `onDialogToggle`-events
- Try restoring `<button>` focus when `core-dialog` is removed
- Fix `z-index` when `core-dialog` is only child of `<body>`

Fixes #333, #332, #330 