### PR TITLE
don't use autofocus for selected date to prevent focus interfering

### DIFF
--- a/packages/core-datepicker/core-datepicker.js
+++ b/packages/core-datepicker/core-datepicker.js
@@ -47,7 +47,7 @@ export default class CoreDatepicker extends HTMLElement {
       if (button && table) dispatchEvent(this, 'datepicker.click.day')
     } else if (event.type === 'keydown' && closest(event.target, 'table')) {
       this.date = KEYS[event.keyCode]
-      this.querySelector('[autofocus]').focus()
+      this.querySelector('[data-selected]').focus()
       event.preventDefault() // Prevent scrolling
     }
   }
@@ -140,7 +140,7 @@ function table (self, table) {
     button.setAttribute('data-adjacent', month !== dayMonth)
     button.setAttribute('aria-label', `${dayInMonth}. ${self.months[dayMonth]}`)
     button.setAttribute('aria-current', day.getDate() === today.getDate() && day.getMonth() === today.getMonth() && day.getFullYear() === today.getFullYear() && 'date')
-    toggleAttribute(button, 'autofocus', isSelected)
+    toggleAttribute(button, 'data-selected', isSelected)
     day.setDate(dayInMonth + 1)
   })
 }

--- a/packages/core-datepicker/core-datepicker.test.js
+++ b/packages/core-datepicker/core-datepicker.test.js
@@ -110,7 +110,7 @@ test('populates empty table', withPage, async (t, page) => {
     t.is(await page.$eval(`core-datepicker thead tr th:nth-child(${i})`, el => el.textContent), days[i - 1])
   }
   t.is(await page.$$eval('core-datepicker table td button[data-adjacent="false"]', els => els.length), 31)
-  t.is(await page.$eval('core-datepicker button[autofocus]', el => el.textContent), '1')
+  t.is(await page.$eval('core-datepicker button[data-selected]', el => el.textContent), '1')
 })
 
 test('marks today\'s date in table', withPage, async (t, page) => {
@@ -133,9 +133,9 @@ test('changes date on day clicked', withPage, async (t, page) => {
     </core-datepicker>
   `)
   await page.waitFor('core-datepicker table button')
-  t.is(await page.$eval('core-datepicker button[autofocus]', el => el.textContent), '1')
+  t.is(await page.$eval('core-datepicker button[data-selected]', el => el.textContent), '1')
   await page.click('core-datepicker tbody tr:nth-child(2) td:nth-child(5) button')
-  t.is(await page.$eval('core-datepicker button[autofocus]', el => el.textContent), '12')
+  t.is(await page.$eval('core-datepicker button[data-selected]', el => el.textContent), '12')
 })
 
 test('changes month names', withPage, async (t, page) => {

--- a/packages/core-datepicker/readme.md
+++ b/packages/core-datepicker/readme.md
@@ -19,7 +19,7 @@
   .my-popup:not([hidden]) { display: block; position: absolute; z-index: 3; padding: 1rem; background: #fff; box-shadow: 0 5px 9px rgba(0,0,0,.4) }
   button[aria-current="date"] { border: 1px dashed }
   button[data-adjacent="true"] { opacity: .3 }
-  button[autofocus] { border: 2px solid }
+  button[data-selected] { border: 2px solid }
   :disabled { filter: brightness(.7) sepia(1) hue-rotate(-50deg) }
 </style>
 demo-->
@@ -305,7 +305,7 @@ myDatepicker.disabled = false // Enable all dates
 .my-datepicker input:checked                  /* Target selected checkbox/radio dates */
 .my-datepicker input:disabled                 /* Target disabled checkbox/radio dates */
 .my-datepicker button:disabled                /* Target disabled dates */
-.my-datepicker button[autofocus]              /* Target the chosen date in month view */
+.my-datepicker button[data-selected]          /* Target the chosen date in month view */
 .my-datepicker button[aria-current="date"]    /* Target current date (today) in month view */
 .my-datepicker button[data-adjacent="false"]  /* Target date in current month in the month view */
 .my-datepicker button[data-adjacent="true"]   /* Target date in next or previous month in the month view */


### PR DESCRIPTION
fixes #322 

currently, using `autofocus` for identifying/styling the selected date button interfers with the focus state. also, `autofocus` behaves differently in firefox from chrome. 
this fix introduces `data-selected` instead for consistent behaviour. 

this requires a major bump on `@nrk/core-datepicker` and `@nrk/origo-datepicker`.