### PR TITLE
Rename `CoreScoll` => `CoreScroll`

### DIFF
--- a/packages/core-scroll/core-scroll.js
+++ b/packages/core-scroll/core-scroll.js
@@ -13,7 +13,7 @@ const EVENT_PASSIVE = ((has = false) => {
 const requestJumps = IS_BROWSER && window.matchMedia && window.matchMedia('(prefers-reduced-motion)').matches
 const requestFrame = IS_BROWSER && (window.requestAnimationFrame || window.setTimeout)
 
-export default class CoreScoll extends HTMLElement {
+export default class CoreScroll extends HTMLElement {
   connectedCallback () {
     // Hide scrollbar in WebKit and default to display block
     addStyle(this.nodeName, `

--- a/packages/core-scroll/readme.md
+++ b/packages/core-scroll/readme.md
@@ -242,7 +242,7 @@ document.addEventListener('scroll.click', (event) => {
 document.addEventListener('scroll', (event) => {
   event.target        // NB: Can be any scrolling element since this is a native event
 
-  // Example check if the event.target is the correct @nrk/core-scoll
+  // Example check if the event.target is the correct @nrk/core-scroll
   if (event.target.id === 'ID-OF-MY-CORE-SCROLL-HERE') {
     // Do Something
   }


### PR DESCRIPTION
Fixes name typo that had me tearing my hair out when matching element named `core-scroll` 💇‍♂ 😂 