### PR TITLE
core-suggest: react to programmatic input value changes

### DIFF
--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -11,7 +11,6 @@ export default class CoreSuggest extends HTMLElement {
     this._observer = new window.MutationObserver(() => onMutation(this)) // Enhance <a> and <button> markup
     this._observer.observe(this, { subtree: true, childList: true, attributes: true, attributeFilter: ['hidden'] })
 
-
     // Observe input.value through input[value]
     this._inputObserver = new window.MutationObserver(() => {
       onMutation(this)
@@ -27,7 +26,7 @@ export default class CoreSuggest extends HTMLElement {
     const superGet = Object.getOwnPropertyDescriptor(superProps, 'value').get
     Object.defineProperty(input, 'value', {
       set (val) {
-        input.setAttribute('value', val)        // Update DOM attribute to trigger observer
+        input.setAttribute('value', val) // Update DOM attribute to trigger observer
         return superSet.apply(input, arguments) // Update IDL property as normal
       },
       get () { return superGet.apply(input, arguments) }


### PR DESCRIPTION
solves #366 

denne løsningen gjør sånn at mutation observer kan reagere på `input.value = '...'`. mutationobserver kan bare kikke på attributter, så ved å overskrive object-setter på input og ved hver set, oppdatere dom-attributten `input[value]`, kan den fyre løs. 

kan med trygghet ryddes opp i koden, bare setter denne her som utgangspunkt.
om det popper opp en bedre/mindre hacky løsning, vil jeg gjerne høre den! har testet at dette funker i ie11