### PR TITLE
Documentation: Return explisit null if not scrollabe

### DIFF
--- a/packages/core-scroll/readme.md
+++ b/packages/core-scroll/readme.md
@@ -82,7 +82,7 @@ demo-->
       this.state = {}
       this.onScroll = this.onScroll.bind(this)
     }
-     onScroll ({target}) {
+    onScroll ({target}) {
       this.setState({
         left: target.scrollLeft ? () => target.scroll('left') : null,
         right: target.scrollRight ? () => target.scroll('right') : null

--- a/packages/core-scroll/readme.md
+++ b/packages/core-scroll/readme.md
@@ -82,10 +82,10 @@ demo-->
       this.state = {}
       this.onScroll = this.onScroll.bind(this)
     }
-    onScroll ({target}) {
+     onScroll ({target}) {
       this.setState({
-        left: target.scrollLeft && (() => target.scroll('left')),
-        right: target.scrollRight && (() => target.scroll('right'))
+        left: target.scrollLeft ? () => target.scroll('left') : null,
+        right: target.scrollRight ? () => target.scroll('right') : null
       })
     }
     render () {


### PR DESCRIPTION
The documentation for react sets the state for right and left to 0 if its not possible to scroll. This creates the error in react `Expected 'onClick' listener to be a function, instead got a value of 'number' type.`

Returning explisit null prevents this error