### PR TITLE
core-datepicker: disable month only if all days are disabled

### DIFF
--- a/packages/core-datepicker/core-datepicker.js
+++ b/packages/core-datepicker/core-datepicker.js
@@ -1,10 +1,19 @@
 import { addStyle, closest, dispatchEvent, toggleAttribute, queryAll } from '../utils'
 import parse from '@nrk/simple-date-parse'
 
+/**
+ * Handlers to fill in date value depending on type of value (as key) selected
+ * e.g. resolve if same day in month can be filled when selecting next month
+ */
 const FILL = {
   month: (self, value) => daysInMonth(self.parse(value)).filter(day => !self.disabled(day))[0] || value,
   null: (_self, value) => value
 }
+
+/**
+ * Handlers to resolve if entity with type of value (as key) is disabled
+ * e.g. resolve if a month can be selected or is disabled
+ */
 const DISABLED = {
   month: (self, value) => daysInMonth(self.parse(value)).map((day) => self.disabled(day)).reduce((a, b) => a && b),
   null: (self, value) => self.disabled(value)

--- a/packages/core-datepicker/core-datepicker.js
+++ b/packages/core-datepicker/core-datepicker.js
@@ -68,8 +68,8 @@ export default class CoreDatepicker extends HTMLElement {
     if (!this.contains(event.target) && !closest(event.target, `[for="${this.id}"],[data-for="${this.id}"]`)) return
 
     if (event.type === 'change') {
-      const date = MASK[event.target.getAttribute('data-type')].replace('*', event.target.value)
-      this.date = FILL[event.target.getAttribute('data-fill')](this, date)
+      const changeMask = MASK[event.target.getAttribute('data-type')].replace('*', event.target.value)
+      this.date = FILL[event.target.getAttribute('data-fill')](this, changeMask)
     } else if (event.type === 'click') {
       const button = closest(event.target, 'button[value]')
       const table = closest(event.target, 'table')

--- a/packages/core-datepicker/core-datepicker.js
+++ b/packages/core-datepicker/core-datepicker.js
@@ -191,11 +191,16 @@ function setupTable (self, table) {
   })
 }
 
+/**
+ *
+ * @param {CoreDatepicker} self
+ * @param {HTMLSelectElement} select
+ */
 function setupSelect (self, select) {
   if (!select.firstElementChild) {
     select._autofill = true
     select.setAttribute('data-fill', 'month')
-    select.innerHTML = self.months.map((name, month) =>
+    select.innerHTML = self.months.map((_, month) =>
       `<option value="y-${month + 1}-d"></option>`
     ).join('')
   }
@@ -207,6 +212,11 @@ function setupSelect (self, select) {
   })
 }
 
+/**
+ * Returns array of days in the month containing the dateInMonth param
+ * @param {Date} dateInMonth
+ * @returns {Date[]} Array of days in the month in question
+ */
 function daysInMonth (dateInMonth) {
   const date = new Date(dateInMonth)
   date.setDate(1)

--- a/packages/core-datepicker/core-datepicker.js
+++ b/packages/core-datepicker/core-datepicker.js
@@ -6,7 +6,11 @@ import parse from '@nrk/simple-date-parse'
  * e.g. resolve if same day in month can be filled when selecting next month
  */
 const FILL = {
-  month: (self, value) => daysInMonth(self.parse(value)).filter(day => !self.disabled(day))[0] || value,
+  month: (self, value) => {
+    if (!self.disabled(value)) return value
+    const firstAvailableDate = daysInMonth(self.parse(value)).filter(day => !self.disabled(day))[0]
+    return firstAvailableDate || value
+  },
   null: (_self, value) => value
 }
 

--- a/packages/core-datepicker/core-datepicker.js
+++ b/packages/core-datepicker/core-datepicker.js
@@ -1,6 +1,14 @@
 import { addStyle, closest, dispatchEvent, toggleAttribute, queryAll } from '../utils'
 import parse from '@nrk/simple-date-parse'
 
+const FILL = {
+  month: (self, value) => daysInMonth(self.parse(value)).filter(day => !self.disabled(day))[0] || value,
+  null: (_self, value) => value
+}
+const DISABLED = {
+  month: (self, value) => daysInMonth(self.parse(value)).map((day) => self.disabled(day)).reduce((a, b) => a && b),
+  null: (self, value) => self.disabled(value)
+}
 const MASK = { year: '*-m-d', month: 'y-*-d', day: 'y-m-*', hour: '*:m', minute: 'h:*', second: 'h:m:*', timestamp: '*', null: '*' }
 const KEYS = { 33: '-1month', 34: '+1month', 35: 'y-m-99', 36: 'y-m-1', 37: '-1day', 38: '-1week', 39: '+1day', 40: '+1week' }
 const MONTHS = 'januar,februar,mars,april,mai,juni,juli,august,september,oktober,november,desember'
@@ -43,7 +51,8 @@ export default class CoreDatepicker extends HTMLElement {
     if (!this.contains(event.target) && !closest(event.target, `[for="${this.id}"],[data-for="${this.id}"]`)) return
 
     if (event.type === 'change') {
-      this.date = MASK[event.target.getAttribute('data-type')].replace('*', event.target.value)
+      const date = MASK[event.target.getAttribute('data-type')].replace('*', event.target.value)
+      this.date = FILL[event.target.getAttribute('data-fill')](this, date)
     } else if (event.type === 'click') {
       const button = closest(event.target, 'button[value]')
       const table = closest(event.target, 'table')
@@ -168,14 +177,28 @@ function setupTable (self, table) {
 function setupSelect (self, select) {
   if (!select.firstElementChild) {
     select._autofill = true
+    select.setAttribute('data-fill', 'month')
     select.innerHTML = self.months.map((name, month) =>
       `<option value="y-${month + 1}-d"></option>`
     ).join('')
   }
-
+  const disabled = DISABLED[select.getAttribute('data-fill')]
   queryAll(select.children).forEach((option, month) => {
     if (select._autofill) option.textContent = self.months[month]
-    option.disabled = self.disabled(option.value)
+    option.disabled = disabled(self, option.value)
     option.selected = !self.diff(option.value)
   })
+}
+
+function daysInMonth (dateInMonth) {
+  const date = new Date(dateInMonth)
+  date.setDate(1)
+
+  const month = date.getMonth()
+  const days = []
+  while (date.getMonth() === month) {
+    days.push(new Date(date))
+    date.setDate(date.getDate() + 1)
+  }
+  return days
 }

--- a/packages/core-datepicker/core-datepicker.js
+++ b/packages/core-datepicker/core-datepicker.js
@@ -19,7 +19,11 @@ const FILL = {
  * e.g. resolve if a month can be selected or is disabled
  */
 const DISABLED = {
-  month: (self, value) => daysInMonth(self.parse(value)).map((day) => self.disabled(day)).reduce((a, b) => a && b),
+  month: (self, value) => {
+    const allDays = daysInMonth(self.parse(value))
+    const allDaysDisabled = allDays.map(day => self.disabled(day)).reduce((a, b) => a && b)
+    return allDaysDisabled
+  },
   null: (self, value) => self.disabled(value)
 }
 const MASK = { year: '*-m-d', month: 'y-*-d', day: 'y-m-*', hour: '*:m', minute: 'h:*', second: 'h:m:*', timestamp: '*', null: '*' }

--- a/packages/core-datepicker/core-datepicker.test.js
+++ b/packages/core-datepicker/core-datepicker.test.js
@@ -352,4 +352,51 @@ describe('core-datepicker', () => {
     await $('button[tabindex="0"]').click()
     await expect(browser.executeScript(() => window.datepickerChange)).toEqual(true)
   })
+
+  it('has month enabled if one day is disabled', async () => {
+    await browser.executeScript(() => {
+      document.body.innerHTML = `
+      <core-datepicker date="${new Date('2019-05-06').getTime()}">
+        <select></select>
+      </core-datepicker>
+      `
+      const disabledDate = new Date('2019-09-06')
+
+      document.querySelector('core-datepicker').disabled = (date) => {
+        return date.valueOf() === disabledDate.valueOf()
+      }
+    })
+    await expect(prop('option[value="y-9-d"]', 'disabled')).toEqual('false')
+  })
+
+  it('has month disabled if all days are disabled', async () => {
+    await browser.executeScript(() => {
+      document.body.innerHTML = `
+        <core-datepicker date="${new Date('2019-05-06').getTime()}">
+          <select></select>
+        </core-datepicker>
+      `
+      document.querySelector('core-datepicker').disabled = (date) => {
+        return date.getMonth() === 8
+      }
+    })
+    await expect(prop('option[value="y-9-d"]', 'disabled')).toEqual('true')
+  })
+
+  it('selects first available date in month', async () => {
+    await browser.executeScript(() => {
+      document.body.innerHTML = `
+        <core-datepicker date="${new Date('2019-12-09T00:00:00.00Z').getTime()}">
+          <select></select>
+          <input type="timestamp">
+        </core-datepicker>
+      `
+      document.querySelector('core-datepicker').disabled = (date) => {
+        return date.getMonth() === 10 && !(date < new Date('2019-11-06') && date > new Date('2019-11-03'))
+      }
+    })
+    await $('option[value="y-11-d"]').click()
+    const browserDate = await browser.executeScript(() => new Date('2019-11-04T00:00:00.00Z').getTime())
+    await expect(prop('input[data-type="timestamp"]', 'value')).toEqual(String(browserDate))
+  })
 })

--- a/packages/core-datepicker/readme.md
+++ b/packages/core-datepicker/readme.md
@@ -166,7 +166,8 @@ Extravagantly featured implementation to showcase most of what you can do out of
 <script>
   // Disable dates past one week from now
   document.getElementById('my-datepicker').disabled = (date) => {
-    var oneWeekFromNow = (new Date()).setDate(new Date().getDate() + 7)
+    var oneWeekFromNow = new Date()
+    oneWeekFromNow.setDate(new Date().getDate() + 7)
     return date > oneWeekFromNow
   }
 


### PR DESCRIPTION
fixes #386

* disables month option if all days is disabled.
* When changing to a month with disabled dates, select the first available