### PR TITLE
toggle: allow override of the role attribute

### DIFF
--- a/packages/core-toggle/core-toggle.js
+++ b/packages/core-toggle/core-toggle.js
@@ -8,7 +8,7 @@ export default class CoreToggle extends HTMLElement {
     if (!IS_ANDROID) this.setAttribute('aria-labelledby', this.button.id = this.button.id || getUUID()) // Andriod reads only label instead of content
 
     this.value = this.button.textContent // Set up aria-label
-    this.setAttribute('role', 'group') // Help Edge
+    this.setAttribute('role', this.attributes.role ? this.attributes.role.value : 'group') // Help Edge
     this.button.setAttribute('aria-expanded', this._open = !this.hidden)
     this.button.setAttribute('aria-controls', this.id = this.id || getUUID())
     document.addEventListener('keydown', this, true) // Use capture to enable checking defaultPrevented (from ESC key) in parents


### PR DESCRIPTION
Allow override of the `role` attribute on the `core-toggle` element. This allows the component to be used as for example custom `select` components that need a ´listbox´ role, or advanced menus using the `menu` role.

The `role` will still default to "group" if it is not specified by the user.

My implementation is super simple and naïve, but seems to work for both plain JS and React versions. I do not have Edge on Windows available for testing, though.