### PR TITLE
core-dialog: respect manually provided z-index

### DIFF
--- a/packages/core-dialog/core-dialog.js
+++ b/packages/core-dialog/core-dialog.js
@@ -38,16 +38,16 @@ export default class CoreDialog extends HTMLElement {
       if (this.hidden) {
         reFocus(this._focus)
       } else {
-        if (!this.style.zIndex) { // Place this dialog over uppermost dialog if not manually controlled
+        let zIndex = window.getComputedStyle(this).getPropertyValue('z-index')
+        if (zIndex === 'auto' && this.style.zIndex === '') { // Place this dialog over uppermost dialog if not manually controlled
           const below = queryAll(this.nodeName).filter((el) => el !== nextBack && !this.contains(el) && isVisible(el))
-          const zIndex = Math.min(Math.max(1, ...below.map(getZIndex)), 2000000000) // Avoid overflowing z-index. See techjunkie.com/maximum-z-index-value
+          zIndex = Math.min(Math.max(1, ...below.map(getZIndex)), 2000000000) // Avoid overflowing z-index. See techjunkie.com/maximum-z-index-value
           if (nextBack) nextBack.style.zIndex = zIndex + 1
           this.style.zIndex = zIndex + 2
         }
         this._focus = document.activeElement || document.body // Remember last focused element
         setTimeout(() => setFocus(this)) // Move focus after paint (helps iOS and react portals)
       }
-
       // React might re-mount the DOM, so make sure prev and next did actually change
       if (attr === 'hidden' && next !== prev) dispatchEvent(this, 'dialog.toggle')
     }
@@ -63,7 +63,6 @@ export default class CoreDialog extends HTMLElement {
 
       if (action === 'close' && closest(event.target, this.nodeName) === this) this.close()
       else if (action === this.id) {
-        button.setAttribute(this._from, '') // iOS remember button
         this.show()
       }
     } else if (event.type === 'keydown' && (event.keyCode === 9 || event.keyCode === 27) && !this.hidden) {

--- a/packages/core-dialog/core-dialog.js
+++ b/packages/core-dialog/core-dialog.js
@@ -35,13 +35,15 @@ export default class CoreDialog extends HTMLElement {
       if (prevBack) prevBack.setAttribute('hidden', '') // Hide previous backdrop
       if (nextBack) toggleAttribute(nextBack, 'hidden', this.hidden)
 
-      if (this.hidden) reFocus(this._focus)
-      else {
-        const below = queryAll('body *').filter((el) => el !== nextBack && !this.contains(el) && isVisible(el))
-        const zIndex = Math.min(Math.max(1, ...below.map(getZIndex)), 2000000000) // Avoid overflowing z-index. See techjunkie.com/maximum-z-index-value
-
-        if (nextBack) nextBack.style.zIndex = zIndex + 1
-        this.style.zIndex = zIndex + 2
+      if (this.hidden) {
+        reFocus(this._focus)
+      } else {
+        if (!this.style.zIndex) { // Place this dialog over uppermost dialog if not manually controlled
+          const below = queryAll(this.nodeName).filter((el) => el !== nextBack && !this.contains(el) && isVisible(el))
+          const zIndex = Math.min(Math.max(1, ...below.map(getZIndex)), 2000000000) // Avoid overflowing z-index. See techjunkie.com/maximum-z-index-value
+          if (nextBack) nextBack.style.zIndex = zIndex + 1
+          this.style.zIndex = zIndex + 2
+        }
         this._focus = document.activeElement || document.body // Remember last focused element
         setTimeout(() => setFocus(this)) // Move focus after paint (helps iOS and react portals)
       }

--- a/packages/core-dialog/core-dialog.js
+++ b/packages/core-dialog/core-dialog.js
@@ -39,7 +39,7 @@ export default class CoreDialog extends HTMLElement {
         reFocus(this._focus)
       } else {
         let zIndex = window.getComputedStyle(this).getPropertyValue('z-index')
-        if (zIndex === 'auto' && this.style.zIndex === '') { // Place this dialog over uppermost dialog if not manually controlled
+        if (zIndex === 'auto' && this.style.zIndex === '') { // Place this dialog over uppermost dialog if not controlled in CSS or JS
           const below = queryAll(this.nodeName).filter((el) => el !== nextBack && !this.contains(el) && isVisible(el))
           zIndex = Math.min(Math.max(1, ...below.map(getZIndex)), 2000000000) // Avoid overflowing z-index. See techjunkie.com/maximum-z-index-value
           if (nextBack) nextBack.style.zIndex = zIndex + 1

--- a/packages/core-dialog/readme.md
+++ b/packages/core-dialog/readme.md
@@ -205,8 +205,9 @@ myDialog.backdrop       // Get backdrop element (if enabled) (see "Markup" for m
 
 // Setters
 myDialog.hidden = false // Open dialog
-myDialog.strict = false // Set strict mode
+myDialog.strict = false // Set strict mode. If set, prevents the dialog from closing on ESC-key and on backdrop click
 myDialog.backdrop = false | true | 'my-drop' // Set boolean to enable/disable backdrop or string ID to point to custom backdrop element
+myDialog.style.zIndex = '9' // Set z-index manually. If unset, z-index is automatically set for both dialog and backdrop element. Default unset.
 
 // Methods
 myDialog.close()        // Close dialog
@@ -247,12 +248,22 @@ content with `<h1 tabindex="-1">Dialog title</h1>`.
 
 ### Elements order
 
-Though not strictly required, the `<button>` opening a dialog should be placed directly before the `<core-dialog>` itself. This eases the mental model for screen reader users.
+Though not strictly required, the `<button>` opening a dialog should be placed directly before the `<core-dialog>` itself. This eases the mental model for screen reader users. Othewise, use `<button for="my-dialog-id"></button>`.
+
+### Stacking
+
+To manually control z-index of dialogs and backdrops, simply set `dialog.style.zIndex` to some number (and `backdrop.style.zIndex` if applicable). The dialog will not try to place itself automatically over the topmost dialog this way and you are responsible for stacking order.
+
+```html
+<core-dialog style="z-index: 100" hidden>...</core-dialog>
+<backdrop style="z-index: 90" hidden>...</backdrop>
+```
 
 ### Backdrop
 
-`core-dialog` automatically creates a `<backdrop>` element as next adjacent sibling if needed. If the `backdrop` attribute is set to an `id` (somehting else than `true|false`), the element with the corresponding ID will be used as backdrop. Note that a backdrop is needed to enable click-outside-to-close. Custom backdrop example:
-```
+`core-dialog` automatically creates a `<backdrop>` element as next adjacent sibling if needed. If the `backdrop` attribute is set to an `id` (something else than `true|false`), the element with the corresponding ID will be used as backdrop. Note that a backdrop is needed to enable click-outside-to-close. Custom backdrop example:
+
+```html
 <core-dialog backdrop="my-backdrop"></core-dialog>
 <div id="my-backdrop"></div>
 ```

--- a/packages/core-dialog/readme.md
+++ b/packages/core-dialog/readme.md
@@ -250,15 +250,6 @@ content with `<h1 tabindex="-1">Dialog title</h1>`.
 
 Though not strictly required, the `<button>` opening a dialog should be placed directly before the `<core-dialog>` itself. This eases the mental model for screen reader users. Othewise, use `<button for="my-dialog-id"></button>`.
 
-### Stacking
-
-To manually control z-index of dialogs and backdrops, simply set `dialog.style.zIndex` to some number (and `backdrop.style.zIndex` if applicable). The dialog will not try to place itself automatically over the topmost dialog this way and you are responsible for stacking order.
-
-```html
-<core-dialog style="z-index: 100" hidden>...</core-dialog>
-<backdrop style="z-index: 90" hidden>...</backdrop>
-```
-
 ### Backdrop
 
 `core-dialog` automatically creates a `<backdrop>` element as next adjacent sibling if needed. If the `backdrop` attribute is set to an `id` (something else than `true|false`), the element with the corresponding ID will be used as backdrop. Note that a backdrop is needed to enable click-outside-to-close. Custom backdrop example:
@@ -268,6 +259,26 @@ To manually control z-index of dialogs and backdrops, simply set `dialog.style.z
 <div id="my-backdrop"></div>
 ```
 
+## Stacking
+
+To manually control z-index of dialogs (and their corresponding backdrop element, set z-index from either HTML, CSS or JS. When set, the dialog will not try to place itself automatically over the topmost dialog and you are responsible for stacking order.
+
+For example:
+
+```html
+<style>
+  .my-dialog { z-index: 100 }
+  .my-backdrop { z-index: 90 }
+</style>
+
+<script>
+  myDialog.style.zIndex = 100
+  myBackdrop.style.zIndex = 90
+</script>
+
+<core-dialog style="z-index: 100" hidden>...</core-dialog>
+<backdrop style="z-index: 90" hidden>...</backdrop>
+```
 
 ## Events
 


### PR DESCRIPTION
solves #392 

* nå kan du sette z-index manuelt på dialoger og backdrops. core-dialog vil da ikke prøve å kalkulerere dette automatisk.

* lar du vær å sette z-index vil den finne høyeste z-index, men bare fra andre åpne core-dialogs. dette burde løse performance problemet.

* <del>note: z-index må settes i js-land</del> sett z-index på dialog og backdrop i html, css eller js

vennligst test med denne branchen lokalt hos dere. takk!

ny dokumentasjon:


## Stacking

To manually control z-index of dialogs (and their corresponding backdrop element, set z-index from either HTML, CSS or JS. When set, the dialog will not try to place itself automatically over the topmost dialog and you are responsible for stacking order.

For example:

```html
<style>
  .my-dialog { z-index: 100 }
  .my-backdrop { z-index: 90 }
</style>

<script>
  myDialog.style.zIndex = 100
  myBackdrop.style.zIndex = 90
</script>

<core-dialog style="z-index: 100" hidden>...</core-dialog>
<backdrop style="z-index: 90" hidden>...</backdrop>
```

