### PR TITLE
Add support for valid HTML5 attribute data-for on control buttons

### DIFF
--- a/packages/core-datepicker/core-datepicker.js
+++ b/packages/core-datepicker/core-datepicker.js
@@ -38,7 +38,7 @@ export default class CoreDatepicker extends HTMLElement {
 
   handleEvent (event) {
     if (event.defaultPrevented || event.ctrlKey || event.metaKey || event.shiftKey || event.altKey || (event.type === 'keydown' && !KEYS[event.keyCode])) return
-    if (!this.contains(event.target) && !closest(event.target, `[for="${this.id}"]`)) return
+    if (!this.contains(event.target) && !closest(event.target, `[for="${this.id}"], [data-for="${this.id}"]`)) return
     if (event.type === 'change') this.date = MASK[event.target.getAttribute('data-type')].replace('*', event.target.value)
     else if (event.type === 'click') {
       const button = closest(event.target, 'button[value]')

--- a/packages/core-scroll/core-scroll.js
+++ b/packages/core-scroll/core-scroll.js
@@ -59,13 +59,13 @@ export default class CoreScroll extends HTMLElement {
     if (event.type === 'wheel') DRAG.animate = false // Stop momentum animation onWheel
     else if (event.type === 'mousedown') onMousedown.call(this, event)
     else if (event.type === 'click') {
-      const btn = this.id && closest(event.target, `[for="${this.id}"]`)
+      const btn = this.id && closest(event.target, `[for="${this.id}"], [data-for="${this.id}"]`)
       if (btn && dispatchEvent(this, 'scroll.click', { move: btn.value })) this.scroll(btn.value)
     } else {
       const scroll = { left: this.scrollLeft, up: this.scrollTop, right: this.scrollRight, down: this.scrollBottom }
       const cursor = (scroll.left || scroll.right || scroll.up || scroll.down) ? 'grab' : ''
 
-      queryAll(this.id && `[for="${this.id}"]`).forEach((el) => (el.disabled = !scroll[el.value]))
+      queryAll(this.id && `[for="${this.id}"], [data-for="${this.id}"]`).forEach((el) => (el.disabled = !scroll[el.value]))
       dispatchEvent(this, 'scroll.change')
 
       if (!event.type) { // Do not change cursor while dragging

--- a/packages/core-toggle/core-toggle.js
+++ b/packages/core-toggle/core-toggle.js
@@ -50,7 +50,7 @@ export default class CoreToggle extends HTMLElement {
 
   get button () {
     if (this._button && this._button.getAttribute('for') === this.id) return this._button // Speed up
-    return (this._button = this.id && document.querySelector(`[for="${this.id}"]`)) || this.previousElementSibling
+    return (this._button = this.id && document.querySelector(`[for="${this.id}"], [data-for="${this.id}]"`)) || this.previousElementSibling
   }
 
   // aria-haspopup triggers forms mode in JAWS, therefore store as custom attr


### PR DESCRIPTION
Currently, there is an option to specify which button controls `core-toggle`, `core-scroll` and `core-datepicker` by setting a `for`-attribute on it. Since this is not a valid attribute for the `<button>` element, it is impractical/impossible in projects using linting, and should probably be avoided in any case.

This adds support for using the generic data-attribute `data-for` instead, which is allowed on all elements.

Suggested by, and closes #463 