### PR TITLE
core-suggest: clear mutation timeout

### DIFF
--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -20,7 +20,7 @@ export default class CoreSuggest extends HTMLElement {
     document.addEventListener('input', this)
     document.addEventListener('keydown', this)
     document.addEventListener('focusin', this)
-    setTimeout(() => onMutation(this)) // Ensure limit is respected
+    this.mutationTimeout = setTimeout(() => onMutation(this)) // Ensure limit is respected
     if (document.activeElement === this.input) this.hidden = false // Open if active
   }
 
@@ -31,6 +31,8 @@ export default class CoreSuggest extends HTMLElement {
     document.removeEventListener('input', this)
     document.removeEventListener('keydown', this)
     document.removeEventListener('focusin', this)
+
+    clearTimeout(this.mutationTimeout);
   }
 
   attributeChangedCallback (name, prev, next) {


### PR DESCRIPTION
We've encountered an issue where we get an error if core-suggest is dismounted to fast after it was rendered. 

Clearing the timeout on disconnect seems to fix this issue. 

Codesandbox: https://codesandbox.io/s/beautiful-hodgkin-89j4g (open your browsers console to see the error) 

![image](https://user-images.githubusercontent.com/10544240/90640417-3bee4500-e230-11ea-9482-a72ced0455f0.png)
