### PR TITLE
Highlight optional

### DIFF
--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -114,7 +114,7 @@ function onMutation (self) {
     const length = needle.length
     const hits = []
 
-    for (let start = 0; ~(start = haystack.indexOf(needle, start)); start += length) hits.push(start)
+    for (let start = 0; (start = haystack.indexOf(needle, start)) !== -1; start += length) hits.push(start)
     for (let start = 0, hitsLength = hits.length, node; (node = iterator.nextNode());) {
       const nodeStart = start
       const nodeEnd = start += node.textContent.length

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -106,7 +106,7 @@ function onMutation (self) {
     toggleItem(items[i], i >= limit)
   }
 
-  // Highlights disabled for iIE11 due to bugs in range calculation
+  // Highlights disabled for IE11 due to bugs in range calculation
   if (needle && self.highlight === 'on' && !IS_IE11) {
     const range = document.createRange()
     const iterator = document.createNodeIterator(self, window.NodeFilter.SHOW_TEXT, null, false)

--- a/packages/core-suggest/core-suggest.test.js
+++ b/packages/core-suggest/core-suggest.test.js
@@ -150,6 +150,66 @@ describe('core-suggest', () => {
     await expect(prop('button[aria-label="Suggest 4, 4 av 3"]', 'hidden')).toMatch(/true/i)
   })
 
+  it('defaults to highlight -attribute "on", stripping existing and adding new <mark>-tags', async () => {
+    await browser.executeScript(() => {
+      document.body.innerHTML = `
+        <input type="text">
+        <core-suggest hidden>
+          <ul>
+            <li><button id="one">Suggest <mark>1</mark></button></li>
+            <li><button id="two">Suggest 2</button></li>
+          </ul>
+        </core-suggest>
+      `
+    })
+    // <mark>-tags are stripped on render
+    await $('input').click()
+    await expect(browser.executeScript(() => (document.querySelector('mark')))).toMatch(/null/i)
+    // matches are wrapped in <mark>-tags
+    await $('input').sendKeys('2')
+    await expect(browser.executeScript(() => (document.querySelector('mark').textContent))).toEqual('2')
+  })
+
+  it('supports highlight -attribute "keep", keeping existing and not adding new <mark>-tags', async () => {
+    await browser.executeScript(() => {
+      document.body.innerHTML = `
+        <input type="text">
+        <core-suggest highlight="keep" hidden>
+          <ul>
+            <li><button id="one">Suggest <mark>1</mark></button></li>
+            <li><button id="two">Suggest 2</button></li>
+          </ul>
+        </core-suggest>
+      `
+    })
+    // <mark>-tags are stripped on render
+    await $('input').click()
+    await expect(browser.executeScript(() => (document.querySelector('mark').textContent))).toEqual('1')
+    // input-matches are not wrapped in <mark>-tags
+    await $('input').sendKeys('2')
+    await expect(browser.executeScript(() => (document.querySelector('mark').textContent))).toEqual('1')
+  })
+
+  it('supports highlight -attribute "off", stripping existing and not adding new <mark>-tags', async () => {
+    await browser.executeScript(() => {
+      document.body.innerHTML = `
+        <input type="text">
+        <core-suggest highlight="off" hidden>
+          <ul>
+            <li><button id="one">Suggest <mark>1</mark></button></li>
+            <li><button id="two">Suggest 2</button></li>
+          </ul>
+        </core-suggest>
+      `
+    })
+    // <mark>-tags are stripped on render
+    await $('input').click()
+    await expect(browser.executeScript(() => (document.querySelector('mark')))).toMatch(/null/i)
+    // input-matches are not wrapped in <mark>-tags
+    await $('input').sendKeys('2')
+    await expect(browser.executeScript(() => (document.querySelector('mark')))).toMatch(/null/i)
+  })
+
   it('triggers ajax event on input ', async () => {
     const server = http.createServer((request, response) => {
       response.writeHead(200, HTTP_HEADERS)

--- a/packages/core-suggest/readme.md
+++ b/packages/core-suggest/readme.md
@@ -80,28 +80,22 @@ Remember to [polyfill](https://github.com/webcomponents/polyfills/tree/master/pa
 
 Typing into the input toggles the [hidden attribute](https://developer.mozilla.org/en/docs/Web/HTML/Global_attributes/hidden) on items of type `<button>` and `<a>`, based on matching [textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) inside `<core-suggest>`. Focusing the input unhides the following element. The default filtering behavior can easily be altered through the `'suggest.select'`, `'suggest.filter'`, `'suggest.ajax'` and  `'suggest.ajax.beforeSend'` [events](#events).
 
+### Security
+
 Results will be rendered in the element inside `<core-suggest>`.
 Always use `coreSuggest.escapeHTML(String)` to safely render data from API or user.
 
-### `highlight` -attribute
+### Highlights
 
-> Accepts `'on', 'off', 'keep'`, defaults to `'on'`.
-
-> Highlighting is disabled for IE11 due to errant behavior.
-
+The `highlight`-attribute accepts `'on', 'off', 'keep'`, defaults to `'on'`.
 Optional attribute to override how core-suggest handles `<mark>`-tags in results.
+Highlighting is disabled for IE11 due to errant behavior.
 
-#### `'on'` (default)
-- Strips existing `<mark>`-tags
-- Wraps matches in `<mark>`-tags
-
-#### `'off'`
-- Strips existing `<mark>`-tags
-- Does not wrap matches
-
-#### `'keep'` (keep existing)
-- Does not strip existing `<mark>`-tags
-- Does not wrap matches
+VALUE | BEHAVIOUR
+:-- | :--
+`'on'` (default) | Strips existing `<mark>`-tags and wraps new matches in `<mark>`-tags
+`'off'` | Strips existing `<mark>`-tags, but does not wrap matches
+`'keep'` | Does not noting with `<mark>`-tags - existing tags are not stripped and no new matches are added
 
 ### HTML / JavaScript
 

--- a/packages/core-suggest/readme.md
+++ b/packages/core-suggest/readme.md
@@ -83,6 +83,26 @@ Typing into the input toggles the [hidden attribute](https://developer.mozilla.o
 Results will be rendered in the element inside `<core-suggest>`.
 Always use `coreSuggest.escapeHTML(String)` to safely render data from API or user.
 
+### `highlight` -attribute
+
+> Accepts `'on', 'off', 'keep'`, defaults to `'on'`.
+
+> Highlighting is disabled for IE11 due to errant behavior.
+
+Optional attribute to override how core-suggest handles `<mark>`-tags in results.
+
+#### `'on'` (default)
+- Strips existing `<mark>`-tags
+- Wraps matches in `<mark>`-tags
+
+#### `'off'`
+- Strips existing `<mark>`-tags
+- Does not wrap matches
+
+#### `'keep'` (keep existing)
+- Does not strip existing `<mark>`-tags
+- Does not wrap matches
+
 ### HTML / JavaScript
 
 
@@ -91,6 +111,7 @@ Always use `coreSuggest.escapeHTML(String)` to safely render data from API or us
        list="{String}">                                 <!-- Optional. Specify id of suggest element -->
 <core-suggest limit="{Number}"                          <!-- Optional. Limit maxium number of result items. Defaults to Infinity -->
               ajax="{String}"                           <!-- Optional. Fetches external data. See event 'suggest.ajax'. Example: 'https://search.com?q={{value}}' -->
+              highlight="{'on' | 'off' | 'keep'}"       <!-- Optional override of highlighting matches in results. Defaults to 'on'.  -->
               hidden>                                   <!-- Use hidden to toggle visibility -->
   <ul>                                                  <!-- Can be any tag, but items should be inside <li> -->
     <li><button>Item 1</button></li>                    <!-- Items must be <button> or <a> -->
@@ -109,11 +130,13 @@ const mySuggest = document.querySelector('core-suggest')
 // Getters
 mySuggest.ajax       // Get ajax URL value
 mySuggest.limit      // Get limit
+mySuggest.highlight  // Get highlight
 mySuggest.hidden     // Get hidden
 mySuggest.input      // Get input for suggest
 // Setters
 mySuggest.ajax = "https://search.com?q={{value}}"    // Set ajax endpoint URL for fetching external data.
 mySuggest.limit = 5                                  // Set limit for results
+mySuggest.highlight = 'on' | 'off' | 'keep'          // Set highlight strategy
 mySuggest.hidden = false                             // Set hidden value
 // Methods
 mySuggest.escapeHTML('<span>...</span>')             // Utility function for escaping HTML string
@@ -259,7 +282,7 @@ All styling in documentation is example only. Both the `<button>` and content el
 .my-input-content[hidden] {}          /* Target only closed content */
 
 .my-input-content :focus {}           /* Target focused item */
-.my-input-content mark {}             /* Target highlighted text (set `background: none;` to disable highlighting) */
+.my-input-content mark {}             /* Target highlighted text (use `highlight='off'` to disable highlighting) */
 ```
 
 

--- a/packages/utils.js
+++ b/packages/utils.js
@@ -1,6 +1,7 @@
 export const IS_BROWSER = typeof window !== 'undefined'
 export const IS_ANDROID = IS_BROWSER && /(android)/i.test(navigator.userAgent) // Bad, but needed
 export const IS_IOS = IS_BROWSER && /iPad|iPhone|iPod/.test(String(navigator.platform))
+export const IS_IE11 = IS_BROWSER && window.msCrypto // msCrypto only exists in IE11
 
 // Mock HTMLElement for Node
 if (!IS_BROWSER && !global.HTMLElement) {


### PR DESCRIPTION
- Add optional attribute `highlight`
  - Support default value `on` for backwards compatibility
  - Support value `off` to remove all `<mark>`-tags
  - Support value `keep` to keep existing/incoming `<mark>`-tags, but not to add based on matches
- Add tests for highlighting functionality
- Don't add `<mark>`-tags for IE11 due to errant behavior
- Replace use of [bitwise NOT operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_NOT) for legibility

Resolves #243 and Closes #373 