### PR TITLE
core-scroll: Remove use of will-change: scroll-position

### DIFF
--- a/packages/core-scroll/core-scroll.js
+++ b/packages/core-scroll/core-scroll.js
@@ -22,7 +22,6 @@ export default class CoreScroll extends HTMLElement {
     `)
 
     this.style.overflow = 'scroll' // Ensure visible scrollbars
-    this.style.willChange = 'scroll-position' // Enhance performance
     this.style.webkitOverflowScrolling = 'touch' // Momentum scroll on iOS
 
     // Calculate sizes for hiding, must be after setting overflow:scroll


### PR DESCRIPTION
Remove use of `will-change: scroll-position` for core-scroll.

We have no way of anticipating when a user will scroll, and can't reliably add/remove it dynamically. 
Should be better off leaving it out than permanently on, especially when doing the latter can lead to performance degradation.

Resolves #446 