### PR TITLE
Core tabs dynamic update

### DIFF
--- a/packages/core-tabs/core-tabs.js
+++ b/packages/core-tabs/core-tabs.js
@@ -12,7 +12,6 @@ export default class CoreTabs extends HTMLElement {
     this.addEventListener('keydown', this)
     if (!this._childObserver) this._childObserver = window.MutationObserver && new window.MutationObserver(updateChildren.bind(null, this))
     if (this._childObserver) this._childObserver.observe(this, { childList: true })
-
     setTimeout(() => updateChildren(this))
   }
 
@@ -46,7 +45,7 @@ export default class CoreTabs extends HTMLElement {
 
   get panels () { return this.tabs.map((tab) => document.getElementById(tab.getAttribute('aria-controls'))) }
 
-  get panel () { return this.panels.filter((panel) => !panel.hasAttribute('hidden'))[0] }
+  get panel () { return this.panels.filter((panel) => panel && !panel.hasAttribute('hidden'))[0] }
 
   get tabs () { return queryAll('button,a', this) }
 

--- a/packages/core-tabs/core-tabs.js
+++ b/packages/core-tabs/core-tabs.js
@@ -39,7 +39,7 @@ export default class CoreTabs extends HTMLElement {
       panel.setAttribute('role', 'tabpanel')
       panel.setAttribute('tabindex', '0')
     })
-    this.tab = this.tab || this.tabs[0] // Setup open
+    this.tab = this.tab || null // Setup open
   }
 
   handleEvent (event) {

--- a/packages/core-tabs/core-tabs.js
+++ b/packages/core-tabs/core-tabs.js
@@ -17,7 +17,6 @@ export default class CoreTabs extends HTMLElement {
   }
 
   connectedChildren () {
-    if (!this.parentNode) return // Abort if removed from DOM
     this.handleChildUpdate()
   }
 
@@ -29,6 +28,7 @@ export default class CoreTabs extends HTMLElement {
   }
 
   handleChildUpdate () {
+    if (!this.parentNode) return // Abort if removed from DOM
     let next = this
     this.tabs.forEach((tab, index) => {
       const panel = document.getElementById(tab.getAttribute('data-for') || tab.getAttribute('for')) || (next = next.nextElementSibling || next)

--- a/packages/core-tabs/core-tabs.js
+++ b/packages/core-tabs/core-tabs.js
@@ -10,11 +10,25 @@ export default class CoreTabs extends HTMLElement {
     this.setAttribute('role', 'tablist')
     this.addEventListener('click', this)
     this.addEventListener('keydown', this)
+    if (!this._childObserver) this._childObserver = window.MutationObserver && new window.MutationObserver(this.handleChildUpdate.bind(this))
+    if (this._childObserver) this._childObserver.observe(this, { childList: true })
+
     setTimeout(() => this.connectedChildren())
   }
 
   connectedChildren () {
     if (!this.parentNode) return // Abort if removed from DOM
+    this.handleChildUpdate()
+  }
+
+  disconnectedCallback () {
+    if (this._childObserver) this._childObserver.disconnect()
+    this.removeEventListener('click', this)
+    this.removeEventListener('keydown', this)
+    this._childObserver = null
+  }
+
+  handleChildUpdate () {
     let next = this
     this.tabs.forEach((tab, index) => {
       const panel = document.getElementById(tab.getAttribute('data-for') || tab.getAttribute('for')) || (next = next.nextElementSibling || next)
@@ -26,11 +40,6 @@ export default class CoreTabs extends HTMLElement {
       panel.setAttribute('tabindex', '0')
     })
     this.tab = this.tab // Setup open
-  }
-
-  disconnectedCallback () {
-    this.removeEventListener('click', this)
-    this.removeEventListener('keydown', this)
   }
 
   handleEvent (event) {

--- a/packages/core-tabs/core-tabs.js
+++ b/packages/core-tabs/core-tabs.js
@@ -39,7 +39,7 @@ export default class CoreTabs extends HTMLElement {
       panel.setAttribute('role', 'tabpanel')
       panel.setAttribute('tabindex', '0')
     })
-    this.tab = this.tab // Setup open
+    this.tab = this.tab || this.tabs[0] // Setup open
   }
 
   handleEvent (event) {
@@ -65,11 +65,11 @@ export default class CoreTabs extends HTMLElement {
 
   get panels () { return this.tabs.map((tab) => document.getElementById(tab.getAttribute('aria-controls'))) }
 
-  get panel () { return this.panels.filter((panel) => !panel.hasAttribute('hidden'))[0] }
+  get panel () { return this.panels.filter((panel) => !panel.hasAttribute('hidden'))[0] || null }
 
   get tabs () { return queryAll('button,a', this) }
 
-  get tab () { return document.getElementById(this.panel.getAttribute(FROM)) }
+  get tab () { return this.panel ? document.getElementById(this.panel.getAttribute(FROM)) : null }
 
   set tab (value) {
     if (!value && value !== 0) return

--- a/packages/core-tabs/core-tabs.test.js
+++ b/packages/core-tabs/core-tabs.test.js
@@ -63,7 +63,7 @@ describe('core-tabs', () => {
     await expect(attr('#tab-3', 'aria-selected')).toEqual('false')
   })
 
-  it('selects first tab by index', async () => {
+  it('accepts 0 as valid value to select first tab by index', async () => {
     await browser.executeScript(() => {
       document.body.innerHTML = `
         <core-tabs>
@@ -195,28 +195,45 @@ describe('core-tabs', () => {
     await expect(browser.executeScript(() => document.querySelector('core-tabs').tab.id)).toEqual('tab-2')
   })
 
-  it('handles dynamically added children', async () => {
+  it('respects hidden panels as indication of active tab', async () => {
+    await browser.executeScript(() => {
+      document.body.innerHTML = `
+        <core-tabs id="dynamicInstance">
+          <button id="tab-1">First tab</button>
+          <button id="tab-2">Second tab</button>
+        </core-tabs>
+        <div id="panel-1" hidden>Text of tab 1</div>
+        <div id="panel-2">Text of tab 2</div>
+      `
+    })
+    await browser.wait(ExpectedConditions.presenceOf($('core-tabs [role="tab"]')))
+    await expect(prop('#panel-1', 'hidden')).toEqual('true')
+    await expect(prop('#panel-2', 'hidden')).toEqual('false')
+    await expect(attr('#tab-2', 'aria-selected')).toEqual('true')
+  })
+
+  it('handles setup and interaction with dynamically added tabs', async () => {
     await browser.executeScript(() => {
       document.body.innerHTML = `
       <core-tabs id="dynamicInstance">
       </core-tabs>
-      <div id="panel-1">Text of tab 1</div>
+      <div id="panel-1" hidden>Text of tab 1</div>
       <div id="panel-2">Text of tab 2</div>
       `
     })
-    await expect(prop('#panel-1', 'hidden')).toMatch(/(null|false)/i)
-    await expect(prop('#panel-2', 'hidden')).toMatch(/(null|false)/i)
+
     await browser.executeScript(() => {
-      const firstButton = document.createElement('button')
-      const secondButton = document.createElement('button')
-      firstButton.appendChild(document.createTextNode('Dynamic tab 1'))
-      secondButton.appendChild(document.createTextNode('Dynamic tab 2'))
+      const firstButton = Object.assign(document.createElement('button'), { id: 'tab-1', textContent: 'Dynamic tab 1' })
+      const secondButton = Object.assign(document.createElement('button'), { id: 'tab-2', textContent: 'Dynamic tab 2' })
       const tabInstance = document.getElementById('dynamicInstance')
       tabInstance.appendChild(firstButton)
       tabInstance.appendChild(secondButton)
     })
+
     await browser.wait(ExpectedConditions.presenceOf($('core-tabs [role="tab"]')))
-    await expect(prop('#panel-1', 'hidden')).toMatch(/(null|false)/i)
-    await expect(prop('#panel-2', 'hidden')).toMatch(/(true)/i)
+    await $('#tab-1').click()
+    await expect(prop('#panel-1', 'hidden')).toEqual('false')
+    await expect(prop('#panel-2', 'hidden')).toEqual('true')
+    await expect(attr('#tab-1', 'aria-selected')).toEqual('true')
   })
 })

--- a/packages/core-tabs/core-tabs.test.js
+++ b/packages/core-tabs/core-tabs.test.js
@@ -194,4 +194,29 @@ describe('core-tabs', () => {
     await expect(tabId).toEqual('tab-2')
     await expect(browser.executeScript(() => document.querySelector('core-tabs').tab.id)).toEqual('tab-2')
   })
+
+  it('handles dynamically added children', async () => {
+    await browser.executeScript(() => {
+      document.body.innerHTML = `
+      <core-tabs id="dynamicInstance">
+      </core-tabs>
+      <div id="panel-1">Text of tab 1</div>
+      <div id="panel-2">Text of tab 2</div>
+      `
+    })
+    await expect(prop('#panel-1', 'hidden')).toMatch(/(null|false)/i)
+    await expect(prop('#panel-2', 'hidden')).toMatch(/(null|false)/i)
+    await browser.executeScript(() => {
+      const firstButton = document.createElement('button')
+      const secondButton = document.createElement('button')
+      firstButton.appendChild(document.createTextNode('Dynamic tab 1'))
+      secondButton.appendChild(document.createTextNode('Dynamic tab 2'))
+      const tabInstance = document.getElementById('dynamicInstance')
+      tabInstance.appendChild(firstButton)
+      tabInstance.appendChild(secondButton)
+    })
+    await browser.wait(ExpectedConditions.presenceOf($('core-tabs [role="tab"]')))
+    await expect(prop('#panel-1', 'hidden')).toMatch(/(null|false)/i)
+    await expect(prop('#panel-2', 'hidden')).toMatch(/(true)/i)
+  })
 })

--- a/packages/core-tabs/readme.md
+++ b/packages/core-tabs/readme.md
@@ -68,6 +68,34 @@ demo-->
 </script>
 ```
 
+```html
+<!--demo-->
+<div id="jsx-dynamic-tabs" class="my-vertical-tabs"></div>
+<script type="text/jsx">
+  const Dynamic = () => {
+      const [elements, setElements] = React.useState([1,2])
+      const menu = elements.map(item => <button type="button">Dynamic Tab {item}</button>);
+      const pages = elements.map(item => <div>Tabpanel {item}</div>);
+
+      return (
+        <>
+          <button type="button" onClick={() => setElements([...elements, elements.length + 1])}>
+            Add extra tab
+          </button>
+          <button type="button" onClick={() => setElements([1,2])}>
+            reset
+          </button>
+          <CoreTabs>
+            {menu}
+          </CoreTabs>
+          {pages}
+        </>
+      )
+    }
+  ReactDOM.render(<Dynamic />, document.getElementById('jsx-dynamic-tabs'))
+</script>
+```
+
 
 ## Installation
 

--- a/packages/core-tabs/readme.md
+++ b/packages/core-tabs/readme.md
@@ -85,6 +85,9 @@ demo-->
           <button type="button" onClick={() => setElements([1,2])}>
             Set to two tabs
           </button>
+          <button type="button" onClick={() => setElements([])}>
+            Remove all
+          </button>
           <CoreTabs>
             {menu}
           </CoreTabs>

--- a/packages/core-tabs/readme.md
+++ b/packages/core-tabs/readme.md
@@ -73,7 +73,7 @@ demo-->
 <div id="jsx-dynamic-tabs" class="my-vertical-tabs"></div>
 <script type="text/jsx">
   const Dynamic = () => {
-      const [elements, setElements] = React.useState([1,2])
+      const [elements, setElements] = React.useState([])
       const menu = elements.map(item => <button type="button">Dynamic Tab {item}</button>);
       const pages = elements.map(item => <div>Tabpanel {item}</div>);
 
@@ -83,7 +83,7 @@ demo-->
             Add extra tab
           </button>
           <button type="button" onClick={() => setElements([1,2])}>
-            reset
+            Set to two tabs
           </button>
           <CoreTabs>
             {menu}


### PR DESCRIPTION
- Handle updates to children of `<CoreTabs>`
- Add dynamic case to readme (simplifies local development)
- Add tests to verify functionality
- Handle corner-cases like when active tab or corresponding panel is removed

Resolves #469 