### PR TITLE
Release tracking

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -58,15 +58,15 @@ if (args.publish) {
   const action = args.publish.replace(/./, (m) => m.toUpperCase()) // Title case action
   const names = update.map(getPackageName).join(', ')
 
+  // Build, test and lint all packages
+  execSync('npm run test', { cwd: process.cwd(), stdio: 'inherit' })
+
   // Bump version in packages
   update.forEach((path) => {
     console.log(`Publishing ${getPackageName(path)}`)
     execSync(`npm version ${args.publish} -m 'Release ${args.publish} %s'`, { cwd: path, stdio: 'inherit' })
     console.log('')
   })
-
-  // Build all packages
-  execSync('npm run build', { cwd: process.cwd(), stdio: 'inherit' })
 
   // Publish all packages
   update.forEach((path) => {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,6 +26,7 @@ export default utils.pkgs.reduce((all, path) => {
   const file = utils.getPackageName(path)
   const name = file.replace(/-./g, (m) => m.slice(-1).toUpperCase())
   const jsx = name.replace(/./, (m) => m.toUpperCase())
+  const bannerText = `/*! @nrk/${file} v${version} - Copyright (c) 2017-${new Date().getFullYear()} NRK */`
 
   return all.concat({
     input: `${path}/${file}.test.js`, // JS CJS (used for testing)
@@ -33,6 +34,7 @@ export default utils.pkgs.reduce((all, path) => {
       format: 'cjs',
       file: `${path}/${file}.test.cjs.js`,
       exports: 'none', // Tests have no exports; set to 'auto' if this changes
+      banner: bannerText,
       globals
     },
     treeshake,
@@ -48,6 +50,7 @@ export default utils.pkgs.reduce((all, path) => {
     output: {
       format: 'cjs',
       file: `${path}/${file}.cjs.js`,
+      banner: bannerText,
       exports: 'default',
       globals
     },
@@ -59,7 +62,7 @@ export default utils.pkgs.reduce((all, path) => {
     output: {
       format: 'umd',
       file: `${path}/${file}.min.js`,
-      banner: `/*! @nrk/${file} v${version} - Copyright (c) 2017-${new Date().getFullYear()} NRK */`,
+      banner: bannerText,
       footer: `window.customElements.define('${file}', ${name})`,
       sourcemap: true,
       globals,
@@ -73,6 +76,7 @@ export default utils.pkgs.reduce((all, path) => {
     output: {
       format: 'cjs',
       file: `${path}/jsx.js`,
+      banner: bannerText,
       exports: 'default',
       globals
     },
@@ -84,6 +88,7 @@ export default utils.pkgs.reduce((all, path) => {
     output: {
       format: 'umd',
       file: `${path}/${file}.jsx.js`,
+      banner: bannerText,
       name: jsx,
       sourcemap: true,
       globals


### PR DESCRIPTION
Edit publishing workflow:
 - Move build-step before npm publishing to always publish latest build
 - Test and lint files as well before publishing
 - Add banner with version and copyright info to all built artefacts making it easier to verify what version is used