### PR TITLE
fix: Add props-declaration of popup to react version of core-toggle

### DIFF
--- a/packages/core-toggle/core-toggle.jsx
+++ b/packages/core-toggle/core-toggle.jsx
@@ -3,6 +3,7 @@ import { version } from './package.json'
 import customElementToReact from '@nrk/custom-element-to-react'
 
 export default customElementToReact(CoreToggle, {
+  props: ['popup'],
   customEvents: ['toggle', 'toggle.select'],
   suffix: version
 })


### PR DESCRIPTION
Most likely just an oversight that this has not been added previously