### PR TITLE
False props

### DIFF
--- a/packages/core-dialog/core-dialog.jsx
+++ b/packages/core-dialog/core-dialog.jsx
@@ -4,6 +4,5 @@ import customElementToReact from '@nrk/custom-element-to-react'
 
 export default customElementToReact(CoreDialog, {
   customEvents: ['dialog.toggle'],
-  props: ['backdrop'],
   suffix: version
 })

--- a/packages/core-dialog/core-dialog.test.js
+++ b/packages/core-dialog/core-dialog.test.js
@@ -115,11 +115,11 @@ describe('core-dialog', () => {
     await expect(prop('#dialog-outer', 'hidden')).toMatch(/true/i)
   })
 
-  it('respects backdrop false option', async () => {
+  it('respects backdrop="off"', async () => {
     await browser.executeScript(() => {
       document.body.innerHTML = `
         <button data-for="dialog">Open</button>
-        <core-dialog id="dialog" backdrop="false" hidden>
+        <core-dialog id="dialog" backdrop="off" hidden>
           <button data-for="close">Close</button>
         </core-dialog>
       `

--- a/packages/core-dialog/readme.md
+++ b/packages/core-dialog/readme.md
@@ -51,58 +51,69 @@
 </style>
 demo-->
 
-## Example
+## Examples
+
+### Plain JavaScript
 
 ```html
 <!--demo-->
-<!-- Normal -->
-<button data-for="my-dialog">Open dialog</button>
+<button data-for="my-dialog" type="button">Open dialog</button>
 <core-dialog id="my-dialog" class="my-dialog" aria-label="first dialog title" hidden>
-  <h1>This is a title</h1>
+  <h1>Dialog title</h1>
   <p>Nunc mi felis, condimentum quis hendrerit sed, porta eget libero. Aenean scelerisque ex eu nisi varius hendrerit. Suspendisse elementum quis massa at vehicula. Nulla lacinia mi pulvinar, venenatis nisi ut, commodo quam. Praesent egestas mi sit amet quam porttitor, mollis mattis mi rhoncus.</p>
-  <button data-for="my-dialog-nested">Open an additional dialog</button>
-  <button type="button" autofocus style="visibility: hidden">Should not be focusable</button>
-  <a href="#">Link</a>
-  <button type="button" autofocus>Autofocus</button>
-  <button data-for="close">Close</button>
+  <label>
+    <small>Label for autofocused input</small>
+    <input type="text" autofocus placeholder="Input with autofocus">
+  </label>
+  <br>
+  <br>
+  <button data-for="close" type="button">Close</button>
+  <button data-for="my-dialog-nested" type="button">Open an additional dialog</button>
   <core-dialog id="my-dialog-nested" class="my-dialog" aria-label="other dialog title" hidden>
     <h1>Another dialog, triggered inside the first dialog</h1>
     <p>Nunc mi felis, condimentum quis hendrerit sed, porta eget libero.</p>
-    <button data-for="close">Close</button>
+    <button data-for="close" type="button">Close</button>
   </core-dialog>
 </core-dialog>
+```
 
-<!-- Strict -->
+```html
+<!--demo-->
 <button data-for="strict-dialog">Open strict dialog</button>
 <core-dialog id="strict-dialog" class="my-dialog" aria-label="strict dialog title" hidden strict>
-  <h1>This is a title</h1>
+  <h1>Strict dialog title</h1>
   <p>Nunc mi felis, condimentum quis hendrerit sed, porta eget libero. Aenean scelerisque ex eu nisi varius hendrerit. Suspendisse elementum quis massa at vehicula. Nulla lacinia mi pulvinar, venenatis nisi ut, commodo quam. Praesent egestas mi sit amet quam porttitor, mollis mattis mi rhoncus.</p>
   <button type="button">This button does nothing</button>
-  <button data-for="close">Close</button>
+  <button data-for="close" type="button">Close</button>
 </core-dialog>
+```
 
-<!-- Modal -->
-<button data-for="modal-dialog">Open modal dialog</button>
-<core-dialog id="modal-dialog" class="my-dialog" aria-label="modal dialog title" hidden backdrop="false">
-  <h1>This is a title</h1>
+```html
+<!--demo-->
+<button data-for="modal-dialog">Open dialog without backdrop</button>
+<core-dialog id="modal-dialog" class="my-dialog" aria-label="modal dialog title" hidden backdrop="off">
+  <h1>Dialog without backdrop</h1>
   <p>Nunc mi felis, condimentum quis hendrerit sed, porta eget libero. Aenean scelerisque ex eu nisi varius hendrerit. Suspendisse elementum quis massa at vehicula. Nulla lacinia mi pulvinar, venenatis nisi ut, commodo quam. Praesent egestas mi sit amet quam porttitor, mollis mattis mi rhoncus.</p>
   <button data-for="close">Close</button>
 </core-dialog>
+```
 
-<!-- Custom backdrop -->
+```html
+<!--demo-->
 <button data-for="modal-custom">Open dialog with custom backdrop</button>
 <core-dialog id="modal-custom" class="my-dialog" aria-label="modal dialog title" hidden backdrop="back-custom">
-  <h1>This is a title</h1>
+  <h1>Dialog title</h1>
   <p>Nunc mi felis, condimentum quis hendrerit sed, porta eget libero. Aenean scelerisque ex eu nisi varius hendrerit. Suspendisse elementum quis massa at vehicula. Nulla lacinia mi pulvinar, venenatis nisi ut, commodo quam. Praesent egestas mi sit amet quam porttitor, mollis mattis mi rhoncus.</p>
   <button data-for="close">Close</button>
 </core-dialog>
 <div id="back-custom" class="my-backdrop" style="background:rgba(0,0,50,.8)" hidden></div>
 ```
 
+### React
+
 ```html
 <!--demo-->
 <div id="jsx-dialog"></div>
-<div id="jsx-dialog-strict"></div>
 <script type="text/jsx">
   class DialogContainerDemo extends React.Component {
     constructor (props) {
@@ -122,8 +133,8 @@ demo-->
 
     render () {
       return (
-        <div>
-          <button onClick={this.toggleDialog}>Open dialog jsx</button>
+        <>
+          <button onClick={this.toggleDialog} type="button">Open React dialog</button>
           <CoreDialog
             className="my-dialog"
             hidden={this.state.hidden}
@@ -131,32 +142,73 @@ demo-->
             aria-label="React dialog">
             <h1>Dialog for JSX</h1>
             <p>Nunc mi felis, condimentum quis hendrerit sed, porta eget libero. Aenean scelerisque ex eu nisi varius hendrerit. Suspendisse elementum quis massa at vehicula. Nulla lacinia mi pulvinar, venenatis nisi ut, commodo quam. Praesent egestas mi sit amet quam porttitor, mollis mattis mi rhoncus.</p>
-            <button onClick={this.toggleDialog}>Lukk</button>
+            <button onClick={this.toggleDialog} type="button">Lukk</button>
           </CoreDialog>
-        </div>
+        </>
       )
     }
   }
 
   ReactDOM.render(<DialogContainerDemo />, document.getElementById('jsx-dialog'))
-  ReactDOM.render(<div>
-    <button data-for="dialog-jsx">Open strict dialog jsx</button>
-    <CoreDialog id="dialog-jsx" className="my-dialog" aria-label="React dialog" hidden strict backdrop>
-      <h1>Strict dialog for JSX</h1>
-      <p>Nunc mi felis, condimentum quis hendrerit sed, porta eget libero. Aenean scelerisque ex eu nisi varius hendrerit. Suspendisse elementum quis massa at vehicula. Nulla lacinia mi pulvinar, venenatis nisi ut, commodo quam. Praesent egestas mi sit amet quam porttitor, mollis mattis mi rhoncus.</p>
-      <button data-for="close">Lukk</button>
-    </CoreDialog>
-    <br />
-    <button data-for="dialog-cust">Open no backdrop</button>
-    <CoreDialog id="dialog-cust" className="my-dialog" aria-label="React dialog without backdrop" backdrop={false} hidden>
-      <h1>Strict dialog for JSX</h1>
-      <p>Nunc mi felis, condimentum quis hendrerit sed, porta eget libero. Aenean scelerisque ex eu nisi varius hendrerit. Suspendisse elementum quis massa at vehicula. Nulla lacinia mi pulvinar, venenatis nisi ut, commodo quam. Praesent egestas mi sit amet quam porttitor, mollis mattis mi rhoncus.</p>
-      <button data-for="close">Lukk</button>
-    </CoreDialog>
-  </div>, document.getElementById('jsx-dialog-strict'))
 </script>
 ```
 
+```html
+<!--demo-->
+<div id="jsx-dialog-strict"></div>
+<script type="text/jsx">
+  ReactDOM.render(
+    <>
+      <button data-for="dialog-strict-jsx" type="button">Open strict React dialog</button>
+      <CoreDialog id="dialog-strict-jsx" className="my-dialog" aria-label="Strict React dialog" hidden strict>
+        <h1>Strict dialog for JSX</h1>
+        <p>Nunc mi felis, condimentum quis hendrerit sed, porta eget libero. Aenean scelerisque ex eu nisi varius hendrerit. Suspendisse elementum quis massa at vehicula. Nulla lacinia mi pulvinar, venenatis nisi ut, commodo quam. Praesent egestas mi sit amet quam porttitor, mollis mattis mi rhoncus.</p>
+        <button data-for="close" type="button">Lukk</button>
+      </CoreDialog>
+    </>,
+    document.getElementById('jsx-dialog-strict')
+  )
+</script>
+```
+
+```html
+<!--demo-->
+<div id="jsx-dialog-no-backdrop"></div>
+<script type="text/jsx">
+  ReactDOM.render(
+    <>
+      <button data-for="dialog-no-back-jsx" type="button">Open React dialog without backdrop</button>
+      <CoreDialog id="dialog-no-back-jsx" className="my-dialog" aria-label="React dialog without backdrop" backdrop="off" hidden>
+        <h1>React dialog without backdrop</h1>
+        <p>Nunc mi felis, condimentum quis hendrerit sed, porta eget libero. Aenean scelerisque ex eu nisi varius hendrerit. Suspendisse elementum quis massa at vehicula. Nulla lacinia mi pulvinar, venenatis nisi ut, commodo quam. Praesent egestas mi sit amet quam porttitor, mollis mattis mi rhoncus.</p>
+        <button data-for="close" type="button">Lukk</button>
+      </CoreDialog>
+    </>,
+    document.getElementById('jsx-dialog-no-backdrop')
+  )
+</script>
+```
+
+```html
+<!--demo-->
+<div id="jsx-dialog-custom"></div>
+<script type="text/jsx">
+  ReactDOM.render(
+    <div>
+      <button data-for="dialog-cust-jsx" type="button">Open React dialog with custom backdrop</button>
+      <CoreDialog id="dialog-cust-jsx" className="my-dialog" aria-label="React dialog with custom backdrop" backdrop="custom-backdrop-jsx" hidden>
+        <h1>React dialog with custom backdrop</h1>
+        <p>Nunc mi felis, condimentum quis hendrerit sed, porta eget libero. Aenean scelerisque ex eu nisi varius hendrerit. Suspendisse elementum quis massa at vehicula. Nulla lacinia mi pulvinar, venenatis nisi ut, commodo quam. Praesent egestas mi sit amet quam porttitor, mollis mattis mi rhoncus.</p>
+        <button data-for="close" type="button">Lukk</button>
+      </CoreDialog>
+      <div id="custom-backdrop-jsx" className="my-backdrop" style={{background:'rgba(0,0,50,.8)'}} hidden></div>
+    </div>,
+    document.getElementById('jsx-dialog-custom')
+  )
+</script>
+```
+
+**NB!** Do not wrap `CoreDialog` with custom backdrop as direct children of React.Fragments (instead, wrap in a block element like `<div>`), to ensure access to the backdrop element on mount.
 
 ## Installation
 
@@ -185,7 +237,7 @@ Remember to [polyfill](https://github.com/webcomponents/polyfills/tree/master/pa
 <core-dialog id="my-dialog"
              hidden                      <!-- Hide dialog by default -->
              strict                      <!-- Optional. If set, prevents the dialog from closing on ESC-key and on backdrop click -->
-             backdrop="{Boolean|String}" <!-- Optional. If false, disables backdrop, string ID points to custom backdrop element -->
+             backdrop="{on|off|String}"  <!-- Optional. Default is "on" and will use standard backdrop. "off" disables backdrop and string ID points to custom backdrop element -->
              aria-label="{String}">      <!-- Optional. Is read by screen readers -->
   <h1>Title of dialog</h1>
   <p>Some content</p>
@@ -207,7 +259,7 @@ myDialog.backdrop       // Get backdrop element (if enabled) (see "Markup" for m
 // Setters
 myDialog.hidden = false // Open dialog
 myDialog.strict = false // Set strict mode. If set, prevents the dialog from closing on ESC-key and on backdrop click
-myDialog.backdrop = false | true | 'my-drop' // Set boolean to enable/disable backdrop or string ID to point to custom backdrop element
+myDialog.backdrop = 'on' | 'off' | 'my-drop' // Set "on"/"off" to enable/disable standard backdrop or string ID to point to custom backdrop element
 myDialog.style.zIndex = '9' // Set z-index manually. If unset, z-index is automatically set for both dialog and backdrop element. Default unset.
 
 // Methods

--- a/packages/core-toggle/core-toggle.jsx
+++ b/packages/core-toggle/core-toggle.jsx
@@ -3,7 +3,6 @@ import { version } from './package.json'
 import customElementToReact from '@nrk/custom-element-to-react'
 
 export default customElementToReact(CoreToggle, {
-  props: ['popup'],
   customEvents: ['toggle', 'toggle.select'],
   suffix: version
 })

--- a/packages/core-toggle/readme.md
+++ b/packages/core-toggle/readme.md
@@ -86,8 +86,9 @@ Remember to [polyfill](https://github.com/webcomponents/polyfills/tree/master/pa
 <button type="button">Toggle VanillaJS</button>       <!-- Must be <button> placed directly before <core-toggle> or use id + data-for attributes -->
 <core-toggle
   hidden                                <!-- Set hidden attribute to prevent FOUC -->
-  popup="{String?}">                    <!-- Optional. If present, clicking outside open toggle will close it. Providing a  string also enables select-behavior, by replacing value inside button with selected value, and suffixes provided string to aria-label on button-->
-  <div>Content</div>
+  popup="{String?}"                    <!-- Optional. If present, clicking outside open toggle will close it. Providing a string also enables select-behavior, by replacing value inside button with selected value, and suffixes provided string to aria-label on button -->
+>
+  Content                               <!-- Content to be toggled. Accepts text, elements and components -->
 </core-toggle>
 ```
 
@@ -104,9 +105,9 @@ myToggle.hidden         // Get hidden value
 myToggle.value          // Get toggle button text
 
 // Setters
-myToggle.popup = true   // Enable or disable if clicking outside toggle should close it. Provide a string to control the aria-label text on the toggle
-myToggle.hidden = true  // Set hidden attribute
-myToggle.value = 'Velg' // Sets innerHTML of the button and safely updates aria-label for screen readers. Defaults to button.innerHTML
+myToggle.popup = {Boolean|String}   // If true, clicking outside open toggle will close it. Providing a string also enables select-behavior, by replacing value inside button with selected value, and suffixes provided string to aria-label on button
+myToggle.hidden = true              // Set hidden attribute
+myToggle.value = 'Velg'             // Sets innerHTML of the button and safely updates aria-label for screen readers. Defaults to button.innerHTML
 ```
 
 ### React / Preact
@@ -114,15 +115,16 @@ myToggle.value = 'Velg' // Sets innerHTML of the button and safely updates aria-
 ```js
 import CoreToggle from '@nrk/core-toggle/jsx'
 
+<button type="button">Use with JSX</button>
 <CoreToggle
   hidden                         // Set hidden attribute to prevent FOUC
-  popup={Boolean|String}         // Optional. Defaults to false. Enable or disable if clicking outside toggle should close it. Provide a string to control the aria-label text on the toggle
+  popup={Boolean|String}         // Optional. If true, clicking outside open toggle will close it. Providing a string also enables select-behavior, by replacing value inside button with selected value, and suffixes provided string to aria-label on button
   ref={(comp) => {}}             // Optional. Get reference to React component
   forwardRef={(el) => {}}        // Optional. Get reference to underlying DOM custom element
   onToggle={Function}            // Optional. Toggle event listener. See event 'toggle'
-  onToggleSelect={Function}>     // Optional. Toggle select event listener. See event 'toggle.select'
-  <button>Use with JSX</button>  // First element must result in a <button>. Accepts both elements and components
-  <div>Content</div>             // Next element will be toggled. Accepts both elements and components
+  onToggleSelect={Function}      // Optional. Toggle select event listener. See event 'toggle.select'
+>
+  Content                        // Content to be toggled. Accepts text, elements and components
 </CoreToggle>
 ```
 
@@ -223,7 +225,7 @@ Content is only toggled when clicking the button. Great for accordions and expan
 
 ```html
 <!--demo-->
-<button>Toggle VanillaJS</button>  <!-- must be <button> -->
+<button type="button">Toggle VanillaJS</button>  <!-- must be <button> -->
 <core-toggle hidden>Content</core-toggle>  <!-- hidden prevents flash of unstyled content -->
 ```
 ```html
@@ -231,7 +233,7 @@ Content is only toggled when clicking the button. Great for accordions and expan
 <div id="jsx-toggle-default"></div>
 <script type="text/jsx">
   ReactDOM.render(<>
-    <button>Toggle JSX</button>
+    <button type="button">Toggle JSX</button>
     <CoreToggle hidden onToggle={console.log}>Content</CoreToggle>
   </>, document.getElementById('jsx-toggle-default'))
 </script>

--- a/packages/core-toggle/readme.md
+++ b/packages/core-toggle/readme.md
@@ -19,12 +19,12 @@ demo-->
 
 ```html
 <!--demo-->
-<button>Popup VanillaJS</button>
+<button type="button">Popup VanillaJS</button>
 <core-toggle class="my-dropdown" popup hidden>
   <ul>
     <li><a>Link</a></li>
     <li>
-      <button>Can also be nested</button>
+      <button type="button">Can also be nested</button>
       <core-toggle class="my-dropdown" popup hidden>
         <ul>
           <li><a>Sub-link</a></li>
@@ -41,13 +41,13 @@ demo-->
 <div id="jsx-toggle-popup"></div>
 <script type="text/jsx">
   ReactDOM.render(<>
-    <button>Popup JSX</button>
+    <button type="button">Popup JSX</button>
     <CoreToggle className='my-dropdown' hidden popup onToggleSelect={console.warn}>
       <ul>
-        <li><button>Select</button></li>
+        <li><button type="button">Select</button></li>
         <li><a href='#'>Link</a></li>
         <li>
-          <button>Can also be nested</button>
+          <button type="button">Can also be nested</button>
           <CoreToggle className='my-dropdown' hidden popup>
             <ul>
               <li><a href='#'>Sub-link</a></li>
@@ -83,7 +83,7 @@ Remember to [polyfill](https://github.com/webcomponents/polyfills/tree/master/pa
 ### HTML / JavaScript
 
 ```html
-<button>Toggle VanillaJS</button>       <!-- Must be <button> placed directly before <core-toggle> or use id + data-for attributes -->
+<button type="button">Toggle VanillaJS</button>       <!-- Must be <button> placed directly before <core-toggle> or use id + data-for attributes -->
 <core-toggle
   hidden                                <!-- Set hidden attribute to prevent FOUC -->
   popup="{Boolean|String}">             <!-- Optional. Defaults to false. Enable or disable if clicking outside toggle should close it. Provide a string to control the aria-label text on the toggle -->
@@ -134,7 +134,7 @@ Putting the toggle button directly before the content is highly recommended, as 
 
 ```html
 <div>
-  <button data-for="my-toggle">Toggle</button>
+  <button data-for="my-toggle" type="button">Toggle</button>
 </div>
 <core-toggle id="my-toggle" hidden>...</core-toggle>
 ```
@@ -144,7 +144,7 @@ Putting the toggle button directly before the content is highly recommended, as 
 Using the `popup` attribute in conjunction with embedded HTML in your toggle button (an SVG icon for instance) will only preserve text when updating the value/label for the button. To preserve the embedded HTML, put the actual button text inside a `<span>`:
 
 ```html
-<button>
+<button type="button">
   <span>Toggle</span>
   <svg style="width:1.5em; height:1.5em" aria-hidden="true"><use xlink:href="#nrk-heart"></use></svg>
 </button>
@@ -247,12 +247,12 @@ to create a component that behaves like a `<select>`:
 
 ```html
 <!--demo-->
-<button>Episode 1</button>
+<button type="button">Episode 1</button>
 <core-toggle class="my-select my-dropdown" hidden popup="Choose episode">
   <ul>
-    <li><button>Episode 1</button></li>
-    <li><button>Episode 2</button></li>
-    <li><button>Episode 3</button></li>
+    <li><button type="button">Episode 1</button></li>
+    <li><button type="button">Episode 2</button></li>
+    <li><button type="button">Episode 3</button></li>
   </ul>
 </core-toggle>
 <script>
@@ -281,12 +281,12 @@ to create a component that behaves like a `<select>`:
     }
     render () {
       return <>
-        <button>{this.state.value}</button>
+        <button type="button">{this.state.value}</button>
         <CoreToggle className='my-dropdown' popup='Example picker' hidden onToggleSelect={this.onSelect}>
           <ul>
-            <li><button>One</button></li>
-            <li><button>Two</button></li>
-            <li><button>Three</button></li>
+            <li><button type="button">One</button></li>
+            <li><button type="button">Two</button></li>
+            <li><button type="button">Three</button></li>
           </ul>
         </CoreToggle>
       </>

--- a/packages/core-toggle/readme.md
+++ b/packages/core-toggle/readme.md
@@ -86,7 +86,7 @@ Remember to [polyfill](https://github.com/webcomponents/polyfills/tree/master/pa
 <button type="button">Toggle VanillaJS</button>       <!-- Must be <button> placed directly before <core-toggle> or use id + data-for attributes -->
 <core-toggle
   hidden                                <!-- Set hidden attribute to prevent FOUC -->
-  popup="{Boolean|String}">             <!-- Optional. Defaults to false. Enable or disable if clicking outside toggle should close it. Provide a string to control the aria-label text on the toggle -->
+  popup="{String?}">                    <!-- Optional. If present, clicking outside open toggle will close it. Providing a  string also enables select-behavior, by replacing value inside button with selected value, and suffixes provided string to aria-label on button-->
   <div>Content</div>
 </core-toggle>
 ```


### PR DESCRIPTION
Remove customElementToReact config of props for
 - core-dialog: `backlog`
 - core-toggle: `popup`

The above mentioned attributes behave less desirably when used only as javaScript properties, and must instead also be present as HTML-attributes on the custom element.

NB! This causes a potentially breaking change to core-dialog:
> Replaces signature of backdrop; true/false or "custom-ID" with "on", "off" or "custom-ID"

Various improvements to related documentation

Resolves #344 