### PR TITLE
Update the aria-labelledby value when switching tab

### DIFF
--- a/packages/core-tabs/core-tabs.js
+++ b/packages/core-tabs/core-tabs.js
@@ -74,7 +74,7 @@ export default class CoreTabs extends HTMLElement {
     let tab = allTabs.filter(tab => tab.getAttribute('aria-selected') === 'true')[0]
 
     // No tab is set, check for match in index or id
-    if (!tab) tab = allTabs[parseInt(tabAttr)] || document.getElementById(tabAttr)
+    if (!tab) tab = allTabs[Number(tabAttr || NaN)] || document.getElementById(tabAttr)
 
     // No tab is set, check for first tab with visible panel
     if (!tab) {

--- a/packages/core-tabs/core-tabs.js
+++ b/packages/core-tabs/core-tabs.js
@@ -8,6 +8,8 @@ const FROM = IS_ANDROID ? 'data-labelledby' : 'aria-labelledby' // Android has a
 const KEYS = { SPACE: 32, END: 35, HOME: 36, LEFT: 37, UP: 38, RIGHT: 39, DOWN: 40 }
 
 export default class CoreTabs extends HTMLElement {
+  static get observedAttributes () { return ['tab'] }
+
   connectedCallback () {
     this.setAttribute('role', 'tablist')
     this.addEventListener('click', this)
@@ -22,6 +24,13 @@ export default class CoreTabs extends HTMLElement {
     this.removeEventListener('click', this)
     this.removeEventListener('keydown', this)
     this._childObserver = null
+  }
+
+  attributeChangedCallback (attr, prev, next) {
+    if (attr === 'tab' && prev !== next) {
+      this.tab = next
+      dispatchEvent(this, 'tabs.toggle')
+    }
   }
 
   handleEvent (event) {

--- a/packages/core-tabs/core-tabs.js
+++ b/packages/core-tabs/core-tabs.js
@@ -125,7 +125,7 @@ export default class CoreTabs extends HTMLElement {
  * @returns {HTMLElement | null} panel
  */
 function getPanelFromTab (tab) {
-  return document.getElementById(tab.getAttribute('aria-controls'))
+  return document.getElementById(tab.getAttribute('data-for') || tab.getAttribute('for') || tab.getAttribute('aria-controls'))
 }
 
 /**
@@ -138,14 +138,19 @@ function getPanelFromTab (tab) {
  */
 function augmentDOM (self) {
   if (!self.parentNode) return // Abort if removed from DOM
-  let next = self
+
+  // Store tabPanel to reference in case no further siblings are found
+  let tabPanel
   self.tabs.forEach((tab) => {
-    const tabPanel = document.getElementById(tab.getAttribute('data-for') || tab.getAttribute('for')) || (next = next.nextElementSibling || next)
+    tabPanel = getPanelFromTab(tab) || (tabPanel || self).nextElementSibling || tabPanel
     tab.id = tab.id || getUUID()
     tab.setAttribute('role', 'tab')
     tab.setAttribute('aria-controls', tabPanel.id = tabPanel.id || getUUID())
-    tabPanel.setAttribute('role', 'tabpanel')
-    tabPanel.setAttribute('tabindex', '0')
+
+    if (tabPanel) {
+      tabPanel.setAttribute('role', 'tabpanel')
+      tabPanel.setAttribute('tabindex', '0')
+    }
   })
   // Setup tab-specific attributes after above iterator has established matching panels and set necessary attributes
   self.tab = self.tab

--- a/packages/core-tabs/core-tabs.js
+++ b/packages/core-tabs/core-tabs.js
@@ -145,9 +145,9 @@ function augmentDOM (self) {
     tabPanel = getPanelFromTab(tab) || (tabPanel || self).nextElementSibling || tabPanel
     tab.id = tab.id || getUUID()
     tab.setAttribute('role', 'tab')
-    tab.setAttribute('aria-controls', tabPanel.id = tabPanel.id || getUUID())
 
     if (tabPanel) {
+      tab.setAttribute('aria-controls', tabPanel.id = tabPanel.id || getUUID())
       tabPanel.setAttribute('role', 'tabpanel')
       tabPanel.setAttribute('tabindex', '0')
     }

--- a/packages/core-tabs/core-tabs.js
+++ b/packages/core-tabs/core-tabs.js
@@ -29,7 +29,6 @@ export default class CoreTabs extends HTMLElement {
   attributeChangedCallback (attr, prev, next) {
     if (attr === 'tab' && prev !== next) {
       this.tab = next
-      dispatchEvent(this, 'tabs.toggle')
     }
   }
 
@@ -95,6 +94,7 @@ export default class CoreTabs extends HTMLElement {
   set tab (value) {
     if (!value && value !== 0) return
     const allTabs = this.tabs
+    const prevTab = this.tab
     const nextTab = allTabs.filter((tab, i) => {
       return i === Number(value) || tab === value || tab.id === value
     })[0] || this.tab
@@ -115,6 +115,11 @@ export default class CoreTabs extends HTMLElement {
     })
 
     this.setAttribute('tab', allTabs.indexOf(nextTab))
+
+    // Dispatch toggle-event when the referenced tab is changed, and not just updating tab-attribute to index from id
+    if (prevTab !== nextTab) {
+      dispatchEvent(this, 'tabs.toggle')
+    }
   }
 }
 

--- a/packages/core-tabs/core-tabs.js
+++ b/packages/core-tabs/core-tabs.js
@@ -67,8 +67,8 @@ export default class CoreTabs extends HTMLElement {
       tab.setAttribute('aria-selected', openTab)
       tab.setAttribute('tabindex', Number(openTab) - 1)
       toggleAttribute(panel, 'hidden', !openPanel)
-      if(openTab) {
-        panel.setAttribute(FROM, tab.id);
+      if (openTab) {
+        panel.setAttribute(FROM, tab.id)
       }
     })
 

--- a/packages/core-tabs/core-tabs.js
+++ b/packages/core-tabs/core-tabs.js
@@ -97,7 +97,7 @@ export default class CoreTabs extends HTMLElement {
     const prevTab = this.tab
     const nextTab = allTabs.filter((tab, i) => {
       return i === Number(value) || tab === value || tab.id === value
-    })[0] || this.tab
+    })[0] || prevTab
     const nextPanel = getPanelFromTab(nextTab)
 
     allTabs.forEach((tab) => {

--- a/packages/core-tabs/core-tabs.js
+++ b/packages/core-tabs/core-tabs.js
@@ -67,6 +67,9 @@ export default class CoreTabs extends HTMLElement {
       tab.setAttribute('aria-selected', openTab)
       tab.setAttribute('tabindex', Number(openTab) - 1)
       toggleAttribute(panel, 'hidden', !openPanel)
+      if(openTab) {
+        panel.setAttribute(FROM, tab.id);
+      }
     })
 
     if (prevIndex !== nextIndex) dispatchEvent(this, 'tabs.toggle')
@@ -81,7 +84,6 @@ function updateChildren (self) {
 
     tab.setAttribute('role', 'tab')
     tab.setAttribute('aria-controls', panel.id = panel.id || getUUID())
-    panel.setAttribute(FROM, tab.id = tab.id || getUUID())
     panel.setAttribute('role', 'tabpanel')
     panel.setAttribute('tabindex', '0')
   })

--- a/packages/core-tabs/core-tabs.js
+++ b/packages/core-tabs/core-tabs.js
@@ -62,7 +62,7 @@ export default class CoreTabs extends HTMLElement {
     const allTabs = this.tabs
     const allPanels = this.panels
 
-    let tab = isInteger(parseInt(tabAttr))
+    let tab = isInteger(Number(tabAttr))
       ? allTabs[tabAttr] // Integer, assume index
       : document.getElementById(tabAttr) // Non-integer, assume id
 
@@ -110,7 +110,7 @@ export default class CoreTabs extends HTMLElement {
       const tabAttr = this.getAttribute('tab')
       if (tabAttr) {
         this.setAttribute('tab',
-          isInteger(parseInt(tabAttr))
+          isInteger(Number(tabAttr))
             ? nextIndex // Integer, set index
             : nextTab && nextTab.id // Non-integer, set id
         )

--- a/packages/core-tabs/core-tabs.js
+++ b/packages/core-tabs/core-tabs.js
@@ -60,15 +60,13 @@ export default class CoreTabs extends HTMLElement {
   get tab () {
     const tabAttr = this.getAttribute('tab')
     const allTabs = this.tabs
-    const allPanels = this.panels
 
     let tab = isInteger(Number(tabAttr))
       ? allTabs[tabAttr] // Integer, assume index
       : document.getElementById(tabAttr) // Non-integer, assume id
 
-    if (!tab) { // No tab is set, check for hidden panels
-      const firstVisiblePanel = allPanels.filter(panel => panel && !panel.hasAttribute('hidden'))[0]
-      tab = allTabs.filter(tab => tab.getAttribute('aria-controls') === (firstVisiblePanel && firstVisiblePanel.id))[0]
+    if (!tab) { // No tab is set, check for visible panel
+      tab = allTabs.filter(tab => !getPanelFromTab(tab).hasAttribute('hidden'))[0] // First tab with visible panel
     }
 
     if (!tab) { tab = allTabs[0] } // No tab, fallback to first tab

--- a/packages/core-tabs/core-tabs.jsx
+++ b/packages/core-tabs/core-tabs.jsx
@@ -3,7 +3,6 @@ import { version } from './package.json'
 import customElementToReact from '@nrk/custom-element-to-react'
 
 export default customElementToReact(CoreTabs, {
-  props: ['tab'],
   customEvents: ['tabs.toggle'],
   suffix: version
 })

--- a/packages/core-tabs/readme.md
+++ b/packages/core-tabs/readme.md
@@ -158,7 +158,9 @@ myTabs.tab = myTab    // Set active tab from element
 ```js
 import CoreTabs from '@nrk/core-tabs/jsx'
 
-<CoreTabs data-for={Number|String}      // Optional. Sets active tab by index or id
+<CoreTabs
+          data-for={String}      // Id to element that re-renders when a new tab is clicked.
+          tab={String}                  // Optional. Sets current active tab by index or id
           ref={(comp) => {}}            // Optional. Get reference to React component
           forwardRef={(el) => {}}       // Optional. Get reference to underlying DOM custom element
           onTabsToggle={Function}>      // Optional. Listen to toggle event

--- a/packages/core-tabs/readme.md
+++ b/packages/core-tabs/readme.md
@@ -287,15 +287,16 @@ myTabs.tab = myTab    // Set active tab from element
 import CoreTabs from '@nrk/core-tabs/jsx'
 
 <CoreTabs
-          tab={String}                  // Optional. Sets current active tab by index or id
-          ref={(comp) => {}}            // Optional. Get reference to React component
-          forwardRef={(el) => {}}       // Optional. Get reference to underlying DOM custom element
-          onTabsToggle={Function}>      // Optional. Listen to toggle event
+  tab={String}                  // Optional. Sets current active tab by index or id
+  ref={(comp) => {}}            // Optional. Get reference to React component
+  forwardRef={(el) => {}}       // Optional. Get reference to underlying DOM custom element
+  onTabsToggle={Function}       // Optional. Listen to toggle event
+>
   <button                  // Tab element must be <a> or <button>. Do not use <li>
     data-for={String}      // Id to element that contains the tab-related content
   >
     Tab 1
-  </button>                
+  </button>
   <a href="#">Tab 2</a>    
 </CoreTabs>
 <div>Tabpanel 1 content</div>           // First tabpanel is the next element sibling of CoreTabs
@@ -335,7 +336,7 @@ All styling in documentation is example only. Both the tabs and tabpanels receiv
 ### Why aren't tabs wrapped in `<ul><li>...</li></ul>`?
 A `<ul>`/`<li>` structure would seem logical for tabs, but this causes some screen readers to incorrectly announce tabs as single (tab 1 of 1).
 
-### Does panels always need be a next element sibling?
+### Must panels always be next element siblings to `<core-tabs>`?
 The aria specification does not allow any elements that are focusable by a screen reader to be placed between tabs and panels. Therefore, `core-tabs` defaults to use the next element siblings as panels.
 This behaviour can be overridden, by setting up `id` on panel elements and the `data-for` attribute on tab element (`for` is deprecated). Use with caution and *only* do this if your project *must* use another DOM structure. Example:
 

--- a/packages/core-tabs/readme.md
+++ b/packages/core-tabs/readme.md
@@ -213,12 +213,12 @@ import CoreTabs from '@nrk/core-tabs/jsx'
           ref={(comp) => {}}            // Optional. Get reference to React component
           forwardRef={(el) => {}}       // Optional. Get reference to underlying DOM custom element
           onTabsToggle={Function}>      // Optional. Listen to toggle event
-  <button
+  <button                  // Tab element must be <a> or <button>. Do not use <li>
     data-for={String}      // Id to element that contains the tab-related content
   >
     Tab 1
   </button>                
-  <a href="#">Tab 2</a>    // Tab element must be <a> or <button>. Do not use <li>
+  <a href="#">Tab 2</a>    
 </CoreTabs>
 <div>Tabpanel 1 content</div>           // First tabpanel is the next element sibling of CoreTabs
 <div hidden>Tabpanel 1 content</div>    // Second tabpanel. Use hidden attribute to prevent FOUC

--- a/packages/core-tabs/readme.md
+++ b/packages/core-tabs/readme.md
@@ -23,8 +23,8 @@
 </style>
 demo-->
 
-## Example
-
+## Examples (plain JS)
+#### Nested tabs
 ```html
 <!--demo-->
 <core-tabs>
@@ -39,13 +39,37 @@ demo-->
     <button>Subtab 2</button>
     <button>Subtab 3</button>
   </core-tabs>
-  <div>Subtabpanel 1</div>
+  <div hidden>Subtabpanel 1</div>
   <div>Subtabpanel 2</div>
-  <div>Subtabpanel 3</div>
+  <div hidden>Subtabpanel 3</div>
 </div>
 <div hidden>Tabpanel 3</div>
 ```
-
+#### Few panels
+```html
+<!--demo-->
+<core-tabs id="few-panels-plain-js" tab="fppj-tab-3">
+  <button type="button" data-for="panel-1" id="fppj-tab-1">First tab</button>
+  <button type="button" data-for="panel-2" id="fppj-tab-2">Second tab</button>
+  <button type="button" data-for="panel-2" id="fppj-tab-3">Third tab</button>
+</core-tabs>
+<div id="panel-1">
+  Text of the first panel
+</div>
+<div id="panel-2">Text of the second panel, shared by second and third tab</div>
+```
+#### Single panel
+```html
+<!--demo-->
+<core-tabs id="single-panel-plain-js" tab='sppj-tab-2'>
+  <button type="button" data-for="only-panel" id="sppj-tab-1">First tab</button>
+  <button type="button" data-for="only-panel" id="sppj-tab-2">Second tab</button>
+  <button type="button" data-for="only-panel" id="sppj-tab-3">Third tab</button>
+</core-tabs>
+<div id="only-panel">Text of the only panel. Note that <code>aria-labelledBy</code> reflects active tab</div>
+```
+## Examples (React)
+#### Nested tabs
 ```html
 <!--demo-->
 <div id="jsx-tabs" class="my-vertical-tabs"></div>
@@ -67,7 +91,7 @@ demo-->
   </div>, document.getElementById('jsx-tabs'))
 </script>
 ```
-
+#### Dynamic tabs
 ```html
 <!--demo-->
 <div id="jsx-dynamic-tabs" class="my-vertical-tabs"></div>
@@ -98,51 +122,58 @@ demo-->
   ReactDOM.render(<Dynamic />, document.getElementById('jsx-dynamic-tabs'))
 </script>
 ```
-
+#### Single panel
 ```html
 <!--demo-->
 <div id="jsx-tabs-2"></div>
 <script type="text/jsx">
   const EpisodeList = ({seasonNumber}) => {
-    const episodes = [["S1: Episode 1", "S1: Episode 2", "S1: Episode 3"], ["S2: Episode 1", "S2: Episode 2"]];
+    const episodes = [
+      ["S1: Episode 1", "S1: Episode 2", "S1: Episode 3"],
+      ["S2: Episode 1", "S2: Episode 2"]
+    ];
 
-    const [episodesInSeason, setEpisodesInSeason] = React.useState(episodes[seasonNumber-1]);
+    const [episodesInSeason, setEpisodesInSeason] = React.useState(episodes[seasonNumber - 1]);
 
     React.useEffect(() => {
-      setEpisodesInSeason(episodes[seasonNumber-1])
+      setEpisodesInSeason(episodes[seasonNumber - 1])
     }, [seasonNumber])
 
     return (
       <div id="episode-list">
-        Table panel: Content here should change: 
+        Table panel for season {seasonNumber}: Content here should change: 
         <br/><br/>
         {episodesInSeason.map(episode => <button>{episode}</button>)}
       </div>
     )
   }
   const SeasonList = () => {
-    const [selectedSeason, setSelectedSeason] = React.useState(1);
+    const [selectedSeason, setSelectedSeason] = React.useState(2);
 
     return (
-      <div>
-        <CoreTabs id="season-list">
+      <>
+        <CoreTabs
+          tab={selectedSeason - 1}
+          id="season-list"
+          onTabsToggle={event => setSelectedSeason(Number(event.target.getAttribute('tab')) + 1)}
+        >
           <button
+            type="button"
             id="season-tab-0"
             data-for="episode-list"
-            onClick={() => setSelectedSeason(1)}
           >
             Season 1
           </button>
           <button
+            type="button"
             id="season-tab-1"
             data-for="episode-list"
-            onClick={() => setSelectedSeason(2)}
           >
             Season 2
           </button>
         </CoreTabs>
         <EpisodeList seasonNumber={selectedSeason} />
-      </div>
+      </>
     )
   }
   ReactDOM.render(<SeasonList />, document.getElementById('jsx-tabs-2'))
@@ -171,10 +202,16 @@ Remember to [polyfill](https://github.com/webcomponents/polyfills/tree/master/pa
 
 ## Usage
 
+### Attributes
+
+Name | Optional | Accepts values | Description
+:-- | :-- | :-- | :--
+`tab` | Yes | `number \| string` | Used to set active tab. Number is index (starting at `0`), string is an id-reference to a tab-element.
+
 ### HTML / JavaScript
 
 ```html
-<core-tabs>
+<core-tabs tab="{string | number}">       <!-- Optional. Used to set active tab String associates id-reference to tab element -->
   <button>Tab 1</button>                  <!-- Tab elements must be <a> or <button>. Do not use <li> -->
   <a href="#">Tab 2</a>
   <button>Tab 3</button>
@@ -234,7 +271,7 @@ import CoreTabs from '@nrk/core-tabs/jsx'
 Fired when toggling a tab:
 
 ```js
-document.addEventListener('tabs.toggle', (event) =>
+document.addEventListener('tabs.toggle', (event) => {
   event.target     // The tabs element
 })
 ```

--- a/packages/core-tabs/readme.md
+++ b/packages/core-tabs/readme.md
@@ -53,7 +53,7 @@ demo-->
   <button type="button" data-for="panel-2" id="fppj-tab-2">Second tab</button>
   <button type="button" data-for="panel-2" id="fppj-tab-3">Third tab</button>
 </core-tabs>
-<div id="panel-1">
+<div id="panel-1" hidden>
   Text of the first panel
 </div>
 <div id="panel-2">Text of the second panel, shared by second and third tab</div>
@@ -72,7 +72,7 @@ demo-->
 #### Nested tabs
 ```html
 <!--demo-->
-<div id="jsx-tabs" class="my-vertical-tabs"></div>
+<div id="react-nested-tabs" class="my-vertical-tabs"></div>
 <script type="text/jsx">
   ReactDOM.render(<div>
     <CoreTabs>
@@ -80,7 +80,7 @@ demo-->
       <button>Vertical tab 2 JSX</button>
     </CoreTabs>
     <div>Tabpanel 1 JSX</div>
-    <div>
+    <div hidden>
       <CoreTabs>
         <button>Subtab 1 JSX</button>
         <button hidden>Subtab 2 JSX</button>
@@ -88,18 +88,18 @@ demo-->
       <div>Subtabpanel 1</div>
       <div hidden>Subtabpanel 2</div>
     </div>
-  </div>, document.getElementById('jsx-tabs'))
+  </div>, document.getElementById('react-nested-tabs'))
 </script>
 ```
 #### Dynamic tabs
 ```html
 <!--demo-->
-<div id="jsx-dynamic-tabs" class="my-vertical-tabs"></div>
+<div id="react-dynamic-tabs" class="my-vertical-tabs"></div>
 <script type="text/jsx">
   const Dynamic = () => {
       const [elements, setElements] = React.useState([])
       const menu = elements.map(item => <button type="button">Dynamic Tab {item}</button>);
-      const pages = elements.map(item => <div>Tabpanel {item}</div>);
+      const pages = elements.map(item => <div hidden>Tabpanel {item}</div>);
 
       return (
         <>
@@ -119,13 +119,13 @@ demo-->
         </>
       )
     }
-  ReactDOM.render(<Dynamic />, document.getElementById('jsx-dynamic-tabs'))
+  ReactDOM.render(<Dynamic />, document.getElementById('react-dynamic-tabs'))
 </script>
 ```
 #### Active by index
 ```html
 <!--demo-->
-<div id="jsx-index-tabs"></div>
+<div id="react-index-tabs"></div>
 <script type="text/jsx">
   const IndexTabs = () => {
       const [tabIndex, setTabIndex] = React.useState(0)
@@ -154,19 +154,19 @@ demo-->
             <button type="button">Tab 4</button>
           </CoreTabs>
           <div>Tabpanel 1</div>
-          <div>Tabpanel 2</div>
-          <div>Tabpanel 3</div>
-          <div>Tabpanel 4</div>
+          <div hidden>Tabpanel 2</div>
+          <div hidden>Tabpanel 3</div>
+          <div hidden>Tabpanel 4</div>
         </>
       )
     }
-  ReactDOM.render(<IndexTabs />, document.getElementById('jsx-index-tabs'))
+  ReactDOM.render(<IndexTabs />, document.getElementById('react-index-tabs'))
 </script>
 ```
 #### Single panel
 ```html
 <!--demo-->
-<div id="jsx-tabs-2"></div>
+<div id="react-single-panel"></div>
 <script type="text/jsx">
   const EpisodeList = ({seasonNumber}) => {
     const episodes = [
@@ -217,7 +217,7 @@ demo-->
       </>
     )
   }
-  ReactDOM.render(<SeasonList />, document.getElementById('jsx-tabs-2'))
+  ReactDOM.render(<SeasonList />, document.getElementById('react-single-panel'))
 </script>
 ```
 
@@ -344,3 +344,6 @@ This behaviour can be overridden, by setting up `id` on panel elements and the `
 const myTabs = document.querySelector('core-tabs')
 myTabs.tabs.forEach((tabs, index) => tab.setAttribute('data-for', myTabs.panels[index].id = 'my-panel-' + index))
 ```
+
+### How do I avoid panels flickering on initialization?
+When you know what panel will be visible on load, all others should have the `hidden`-attribute to avoid [Flash of unstyled content](https://en.wikipedia.org/wiki/Flash_of_unstyled_content) (FOUC). If the active panel is unknown to your template, set `hidden`-attribute on all panels initially.

--- a/packages/core-tabs/readme.md
+++ b/packages/core-tabs/readme.md
@@ -122,6 +122,47 @@ demo-->
   ReactDOM.render(<Dynamic />, document.getElementById('jsx-dynamic-tabs'))
 </script>
 ```
+#### Active by index
+```html
+<!--demo-->
+<div id="jsx-index-tabs"></div>
+<script type="text/jsx">
+  const IndexTabs = () => {
+      const [tabIndex, setTabIndex] = React.useState(0)
+      const handleTabsToggle = (event) => { setTabIndex(parseInt(event.target.getAttribute('tab'))) }
+      const handleInputChange = (event) => { setTabIndex(parseInt(event.target.value)) }
+
+      return (
+        <>
+          <div>
+            <label>
+              Set active tab
+              <input
+                type="range"
+                value={tabIndex}
+                min="0"
+                max="3"
+                step="1"
+                onChange={handleInputChange}
+              />
+            </label>
+          </div>
+          <CoreTabs tab={tabIndex} onTabsToggle={handleTabsToggle}>
+            <button type="button">Tab 1</button>
+            <button type="button">Tab 2</button>
+            <button type="button">Tab 3</button>
+            <button type="button">Tab 4</button>
+          </CoreTabs>
+          <div>Tabpanel 1</div>
+          <div>Tabpanel 2</div>
+          <div>Tabpanel 3</div>
+          <div>Tabpanel 4</div>
+        </>
+      )
+    }
+  ReactDOM.render(<IndexTabs />, document.getElementById('jsx-index-tabs'))
+</script>
+```
 #### Single panel
 ```html
 <!--demo-->

--- a/packages/core-tabs/readme.md
+++ b/packages/core-tabs/readme.md
@@ -99,6 +99,56 @@ demo-->
 </script>
 ```
 
+```html
+<!--demo-->
+<div id="jsx-tabs-2"></div>
+<script type="text/jsx">
+  const EpisodeList = ({seasonNumber}) => {
+    const episodes = [["S1: Episode 1", "S1: Episode 2", "S1: Episode 3"], ["S2: Episode 1", "S2: Episode 2"]];
+
+    const [episodesInSeason, setEpisodesInSeason] = React.useState(episodes[seasonNumber-1]);
+
+    React.useEffect(() => {
+      setEpisodesInSeason(episodes[seasonNumber-1])
+    }, [seasonNumber])
+
+    return (
+      <div id="episode-list">
+        Table panel: Content here should change: 
+        <br/><br/>
+        {episodesInSeason.map(episode => <button>{episode}</button>)}
+      </div>
+    )
+  }
+  const SeasonList = () => {
+    const [selectedSeason, setSelectedSeason] = React.useState(1);
+
+    return (
+      <div>
+        <CoreTabs id="season-list">
+          <button
+            id="season-tab-0"
+            data-for="episode-list"
+            onClick={() => setSelectedSeason(1)}
+          >
+            Season 1
+          </button>
+          <button
+            id="season-tab-1"
+            data-for="episode-list"
+            onClick={() => setSelectedSeason(2)}
+          >
+            Season 2
+          </button>
+        </CoreTabs>
+        <EpisodeList seasonNumber={selectedSeason} />
+      </div>
+    )
+  }
+  ReactDOM.render(<SeasonList />, document.getElementById('jsx-tabs-2'))
+</script>
+```
+
 
 ## Installation
 

--- a/packages/core-tabs/readme.md
+++ b/packages/core-tabs/readme.md
@@ -159,13 +159,16 @@ myTabs.tab = myTab    // Set active tab from element
 import CoreTabs from '@nrk/core-tabs/jsx'
 
 <CoreTabs
-          data-for={String}      // Id to element that re-renders when a new tab is clicked.
           tab={String}                  // Optional. Sets current active tab by index or id
           ref={(comp) => {}}            // Optional. Get reference to React component
           forwardRef={(el) => {}}       // Optional. Get reference to underlying DOM custom element
           onTabsToggle={Function}>      // Optional. Listen to toggle event
-  <button>Tab 1</button>                // Tab elements must be <a> or <button>. Do not use <li>
-  <a href="#">Tab 2</a>
+  <button
+    data-for={String}      // Id to element that contains the tab-related content
+  >
+    Tab 1
+  </button>                
+  <a href="#">Tab 2</a>    // Tab element must be <a> or <button>. Do not use <li>
 </CoreTabs>
 <div>Tabpanel 1 content</div>           // First tabpanel is the next element sibling of CoreTabs
 <div hidden>Tabpanel 1 content</div>    // Second tabpanel. Use hidden attribute to prevent FOUC

--- a/packages/utils.js
+++ b/packages/utils.js
@@ -145,7 +145,7 @@ export function queryAll (elements, context = document) {
 /**
  * isInteger as a substitute for Number.isInteger due to lacking IE-support
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger
- * @param {*} val
+ * @param {Number} val
  * @returns {Boolean}
  */
 export function isInteger (val) {

--- a/packages/utils.js
+++ b/packages/utils.js
@@ -141,15 +141,3 @@ export function queryAll (elements, context = document) {
   }
   return []
 }
-
-/**
- * isInteger as a substitute for Number.isInteger due to lacking IE-support
- * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger
- * @param {Number} val
- * @returns {Boolean}
- */
-export function isInteger (val) {
-  const isCallable = typeof val === 'function'
-  const isObject = typeof val === 'object' ? val !== null : isCallable
-  return !isObject && isFinite(val) && Math.floor(val) === val
-}

--- a/packages/utils.js
+++ b/packages/utils.js
@@ -141,3 +141,15 @@ export function queryAll (elements, context = document) {
   }
   return []
 }
+
+/**
+ * isInteger as a substitute for Number.isInteger due to lacking IE-support
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger
+ * @param {*} val
+ * @returns {Boolean}
+ */
+export function isInteger (val) {
+  const isCallable = typeof val === 'function'
+  const isObject = typeof val === 'object' ? val !== null : isCallable
+  return !isObject && isFinite(val) && Math.floor(val) === val
+}


### PR DESCRIPTION
I think the current implementation just sets the` aria-labelledby` field when children are updated, I could not see it being updated when choosing another tab? I might be mistaken, just wanted to easily show what i meant to more efficiently start a discussion, this is what I observed with and without this change on tv.nrk.no (using the series stjernekamp as an example):

Update: Found out that this only happens when you have _one_ element intended to work as a `tabpanel`, meaning content gets re-rendered when a new tab is selected (which is what we do on tv.nrk.no, typically react?). In the already existing examples, a `tablist` element exists for each tab in the dom, they are just hidden when the tab is not selected. Built a new example to showcase this, take a look and tell me what you think. I might be mistaken, would love for some input on how to solve it otherwise if you think this is not the correct solution/we use it wrongly.

## Before
The `aria-labelledby` is always just the last tab (as this naturally is the last tab when looping through all tabs in `updatingChildren`, and each time the panel `aria-labelledby` is set to an id, see deleted code). 

E.g. when season 5 is selected, the `aria-labelledby` still directs to the tenth tab, meaning users dependent on the accessibility attributes will get read "Sesong 10" when in fact the episode list shows episodes for season 5?
![image](https://user-images.githubusercontent.com/72200992/139047918-549cf3de-6db7-4966-ae4e-40f14736e83e.png)


This is how the dom looks with my example before: (see the bottom `aria-labelledby` never changes value when switching tabs)

https://user-images.githubusercontent.com/72200992/139080574-ffd6dceb-0e49-407c-b9e8-83f88fb5d9cb.mp4


## After
The `aria-labelledby` attribute matches the id of the selected tab, and is updated when choosing an other tab:
![image](https://user-images.githubusercontent.com/72200992/139047497-4e1f8e5e-9e88-4e08-b9b3-cb9b4052b5c4.png)

My example with the changes in this PR: (see the bottom `aria-labelledby` changes value to the correct tab id when switching tabs)


https://user-images.githubusercontent.com/72200992/139080673-76413186-efc6-43c4-bdb7-d2968c46a9e2.mp4
