### PR TITLE
dep: Bump axios to 0.24.0 and use follow-redirects >= 1.14.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@rollup/plugin-json": "4.1.0",
         "@rollup/plugin-node-resolve": "13.0.5",
         "@webcomponents/custom-elements": "1.5.0",
-        "axios": "0.22.0",
+        "axios": "0.24.0",
         "dotenv": "10.0.0",
         "esm": "3.2.25",
         "fast-glob": "3.2.7",
@@ -1993,9 +1993,9 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.22.0.tgz",
-      "integrity": "sha512-Z0U3uhqQeg1oNcihswf4ZD57O3NrR1+ZXhxaROaWpDmsDTx7T2HNBV2ulBtie2hwJptu8UvgnJoK+BIqdzh/1w==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "dev": true,
       "dependencies": {
         "follow-redirects": "^1.14.4"
@@ -3320,9 +3320,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-      "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==",
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
       "dev": true,
       "funding": [
         {
@@ -7908,9 +7908,9 @@
       "dev": true
     },
     "axios": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.22.0.tgz",
-      "integrity": "sha512-Z0U3uhqQeg1oNcihswf4ZD57O3NrR1+ZXhxaROaWpDmsDTx7T2HNBV2ulBtie2hwJptu8UvgnJoK+BIqdzh/1w==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "dev": true,
       "requires": {
         "follow-redirects": "^1.14.4"
@@ -8932,9 +8932,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-      "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==",
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
       "dev": true
     },
     "forever-agent": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@rollup/plugin-json": "4.1.0",
     "@rollup/plugin-node-resolve": "13.0.5",
     "@webcomponents/custom-elements": "1.5.0",
-    "axios": "0.22.0",
+    "axios": "0.24.0",
     "dotenv": "10.0.0",
     "esm": "3.2.25",
     "fast-glob": "3.2.7",


### PR DESCRIPTION
Address CVE-2022-0155
https://github.com/advisories/GHSA-74fj-2j2h-c42q

* Use latest available version of axios
* Lock transient dependency follow-redirects >= 1.14.7