### PR TITLE
Core suggest aria-live

### DIFF
--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -141,17 +141,8 @@ export default class CoreSuggest extends HTMLElement {
  */
 function appendResultsNotificationSpan (self) {
   if (!self._observer) return // Abort if disconnectedCallback has been called
-  const resultsNotificationSpan = document.createElement('span')
-  resultsNotificationSpan.setAttribute('aria-live', 'polite')
-  resultsNotificationSpan.setAttribute('style', `
-    position: absolute !important;
-    overflow: hidden !important;
-    width: 1px !important;
-    height: 1px !important;
-    clip: rect(0, 0, 0, 0) !important;
-  `)
-  self.appendChild(resultsNotificationSpan)
-  return resultsNotificationSpan
+  self.insertAdjacentHTML('beforeend', '<span aria-live="polite" style="position: absolute !important; overflow: hidden !important; width: 1px !important; height: 1px !important; clip: rect(0, 0, 0, 0) !important"></span>')
+  return self.lastElementChild
 }
 
 /**

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -85,9 +85,15 @@ export default class CoreSuggest extends HTMLElement {
    */
   pushToLiveRegion (label) {
     if (!this._observer || !this._ariaLiveSpan) return // Abort if disconnectedCallback has been called or no _ariaLiveSpan
-    clearTimeout(this._ariaLiveTimeout) // Clear existing timeout
-    this._ariaLiveSpan.textContent = label
-    this._ariaLiveTimeout = setTimeout(() => (this._clearLiveRegion()), ARIA_LIVE_DELAY)
+    clearTimeout(this._ariaLiveDebounce) // Debounce multiple calls in the delay-interval
+
+    // Delaying the update of textContent is necesary for consistent behavior in NVDA
+    this._ariaLiveDebounce = setTimeout(() => {
+      clearTimeout(this._ariaLiveTimeout) // Clear existing timeout
+      this._ariaLiveSpan.textContent = label
+      // Delay clearing to successfully register change in textContent with screen readers
+      this._ariaLiveTimeout = setTimeout(() => (this._clearLiveRegion()), ARIA_LIVE_DELAY)
+    }, ARIA_LIVE_DELAY)
   }
 
   /**

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -291,7 +291,7 @@ function onInput (self, event) {
     toggleItem(items[i], (items[i].value || items[i].textContent).toLowerCase().indexOf(value) === -1)
   }
 
-  if (items.length > 0) {
+  if (!self.empty) {
     const visibleItems = queryAll('[tabindex="-1"]:not([hidden])', self)
     if (visibleItems.length === 0) {
       // All items have been hidden by filter

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -16,7 +16,7 @@ const KEY = {
 const AJAX_DEBOUNCE = 500
 const ARIA_LIVE_DELAY = 100 // 100 ms established as sufficient, through testing.
 const ARIA_LIVE_FILTERED = 'Ingen forslag'
-const ARIA_LIVE_COUNT = '{{value}} forslag'
+const ARIA_LIVE_COUNT = '{{value}} forslag vises'
 
 export default class CoreSuggest extends HTMLElement {
   static get observedAttributes () { return ['hidden', 'highlight'] }

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -26,13 +26,13 @@ export default class CoreSuggest extends HTMLElement {
     this._observer = new window.MutationObserver(() => onMutation(this)) // Enhance <a> and <button> markup
     this._observer.observe(this, { subtree: true, childList: true, attributes: true, attributeFilter: ['hidden'] })
     this._xhr = new window.XMLHttpRequest()
-    this._id = this.getAttribute('id') ? this.getAttribute('id') : getUUID()
+    this.id = this.id || getUUID()
 
     if (IS_IOS) this.input.setAttribute('role', 'combobox') // iOS does not inform about editability if combobox
     this.input.setAttribute('autocomplete', 'off')
     this.input.setAttribute('aria-autocomplete', 'list')
     this.input.setAttribute('aria-expanded', false)
-    this.input.setAttribute('aria-controls', this._id)
+    this.input.setAttribute('aria-controls', this.id)
 
     this._ariaLiveSpan = appendResultsNotificationSpan(this)
 

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -57,9 +57,7 @@ export default class CoreSuggest extends HTMLElement {
 
   attributeChangedCallback (name) {
     if (!this._observer) return
-    if (name === 'hidden') {
-      this.input.setAttribute('aria-expanded', !this.hidden)
-    }
+    if (name === 'hidden') this.input.setAttribute('aria-expanded', !this.hidden)
     if (name === 'highlight') onMutation(this)
   }
 
@@ -86,6 +84,7 @@ export default class CoreSuggest extends HTMLElement {
    * @returns {void}
    */
   pushToLiveRegion (label) {
+    if (!this._observer || !this._ariaLiveSpan) return // Abort if disconnectedCallback has been called or no _ariaLiveSpan
     clearTimeout(this._ariaLiveTimeout) // Clear existing timeout
     this._ariaLiveSpan.textContent = label
     this._ariaLiveTimeout = setTimeout(() => (this._clearLiveRegion()), ARIA_LIVE_DELAY)
@@ -156,7 +155,6 @@ function notifyTextContent (self, textContent) {
  * @returns {void}
  */
 function notifyResultCount (self, items) {
-  if (!self._observer) return // Abort if disconnectedCallback has been called
   const label = self.getAttribute('data-sr-count-message')
   if (label === '') return // Abort if label is set to explicit empty string
   self.pushToLiveRegion((label || ARIA_LIVE_COUNT).replace('{{value}}', items))
@@ -170,7 +168,6 @@ function notifyResultCount (self, items) {
  * @returns {void}
  */
 function notifyResultsEmpty (self) {
-  if (!self._observer) return // Abort if disconnectedCallback has been called
   const label = self.getAttribute('data-sr-empty-message')
   if (label === '') return // Abort if label is set to explicit empty string
   self.pushToLiveRegion(label || ARIA_LIVE_FILTERED)

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -20,7 +20,7 @@ const ARIA_LIVE_FILTERED = 'Ingen forslag'
 const ARIA_LIVE_COUNT = '{{value}} forslag'
 
 export default class CoreSuggest extends HTMLElement {
-  static get observedAttributes () { return ['hidden', 'highlight', 'empty'] }
+  static get observedAttributes () { return ['hidden', 'highlight'] }
 
   connectedCallback () {
     this._observer = new window.MutationObserver(() => onMutation(this)) // Enhance <a> and <button> markup
@@ -129,10 +129,6 @@ export default class CoreSuggest extends HTMLElement {
   get hidden () { return this.hasAttribute('hidden') }
 
   set hidden (val) { toggleAttribute(this, 'hidden', val) }
-
-  get empty () { return this.hasAttribute('empty') }
-
-  set empty (val) { toggleAttribute(this, 'empty', val) }
 }
 
 /**
@@ -225,7 +221,7 @@ function onMutation (self) {
     }
   }
 
-  self.empty = items.length === 0
+  self._empty = items.length === 0
 
   for (let i = 0, l = items.length; i < l; ++i) {
     items[i].setAttribute('aria-label', `${items[i].textContent}, ${i + 1} av ${limit}`)

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -52,12 +52,18 @@ export default class CoreSuggest extends HTMLElement {
     this._observer = this._input = this._regex = this._xhr = this._xhrTime = this._ariaLiveDelay = this._ariaLiveTimeout = this._ariaLiveSpan = null
   }
 
-  attributeChangedCallback (name, prev, next) {
+  attributeChangedCallback (name) {
     if (!this._observer) return
     if (name === 'hidden') {
       this.input.setAttribute('aria-expanded', !this.hidden)
-      if (this._ariaLiveDelay) clearTimeout(this._ariaLiveDelay)
-      this._ariaLiveDelay = setTimeout(() => notifyResultsVisible(this, this.hidden), ARIA_LIVE_DELAY)
+    }
+    if (name === 'empty' || name === 'hidden') {
+      // Notify screen readers when visible and list has content
+      if (!this.empty && !this.hidden) {
+        // Clear if there is an existing delay
+        if (this._ariaLiveDelay) clearTimeout(this._ariaLiveDelay)
+        this._ariaLiveDelay = setTimeout(() => notifyResultsVisible(this, this.hidden), ARIA_LIVE_DELAY)
+      }
     }
     if (name === 'highlight') onMutation(this)
   }

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -87,7 +87,6 @@ export default class CoreSuggest extends HTMLElement {
    * @returns {void}
    */
   pushToLiveRegion (label) {
-    if (this._ariaLiveSpan.textContent === label) return // Abort duplicates
     clearTimeout(this._ariaLiveTimeout) // Clear existing timeout
     this._ariaLiveSpan.textContent = label
     this._ariaLiveTimeout = setTimeout(() => (this._clearLiveRegion()), ARIA_LIVE_DELAY)

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -14,7 +14,7 @@ const KEY = {
   PAGEUP: 'PageUp'
 }
 const AJAX_DEBOUNCE = 500
-const ARIA_LIVE_DELAY = 100 // 100 ms established as sufficient, through testing, to not be invasive of expected behavior
+const ARIA_LIVE_DELAY = 150 // 150 ms established as sufficient, through testing, to not be invasive of expected screen-reader behavior
 
 export default class CoreSuggest extends HTMLElement {
   static get observedAttributes () { return ['hidden', 'highlight'] }

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -1,6 +1,18 @@
 import { closest, dispatchEvent, escapeHTML, IS_IE11, IS_IOS, queryAll, toggleAttribute } from '../utils'
 
-const KEYS = { ENTER: 13, ESC: 27, PAGEUP: 33, PAGEDOWN: 34, END: 35, HOME: 36, UP: 38, DOWN: 40 }
+const KEY = {
+  DOWN_IE: 'Down',
+  DOWN: 'ArrowDown',
+  UP_IE: 'Up',
+  UP: 'ArrowUp',
+  ENTER: 'Enter',
+  ESC_IE: 'Esc',
+  ESC: 'Escape',
+  END: 'End',
+  HOME: 'Home',
+  PAGEDOWN: 'PageDown',
+  PAGEUP: 'PageUp'
+}
 const AJAX_DEBOUNCE = 500
 
 export default class CoreSuggest extends HTMLElement {
@@ -221,18 +233,25 @@ function onInput (self, event) {
 function onKey (self, event) {
   if (!self.contains(event.target) && self.input !== event.target) return
   const items = [self.input].concat(queryAll('[tabindex="-1"]:not([hidden])', self))
-  let { keyCode, target, item = false } = event
+  let { key, target, item = false } = event
 
-  if (keyCode === KEYS.DOWN) item = items[items.indexOf(target) + 1] || items[0]
-  else if (keyCode === KEYS.UP) item = items[items.indexOf(target) - 1] || items.pop()
-  else if (self.contains(target)) { // Aditional shortcuts if focus is inside list
-    if (keyCode === KEYS.END || keyCode === KEYS.PAGEDOWN) item = items.pop()
-    else if (keyCode === KEYS.HOME || keyCode === KEYS.PAGEUP) item = items[1]
-    else if (keyCode !== KEYS.ENTER) items[0].focus()
+  if (key === KEY.DOWN || key === KEY.DOWN_IE) {
+    item = items[items.indexOf(target) + 1] || items[0]
+  } else if (key === KEY.UP || key === KEY.UP_IE) {
+    item = items[items.indexOf(target) - 1] || items.pop()
+  } else if (self.contains(target)) {
+    // Aditional shortcuts if focus is inside list
+    if (key === KEY.END || key === KEY.PAGEDOWN) {
+      item = items.pop()
+    } else if (key === KEY.HOME || key === KEY.PAGEUP) {
+      item = items[1]
+    } else if (key !== KEY.ENTER) {
+      items[0].focus()
+    }
   }
 
-  setTimeout(() => (self.hidden = keyCode === KEYS.ESC)) // Let focus buble first
-  if (item || keyCode === KEYS.ESC) event.preventDefault() // Prevent leaving maximized safari
+  setTimeout(() => (self.hidden = (key === KEY.ESC || key === KEY.ESC_IE))) // Let focus buble first
+  if (item || (key === KEY.ESC || key === KEY.ESC_IE)) event.preventDefault() // Prevent leaving maximized safari
   if (item) item.focus()
 }
 

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -14,7 +14,7 @@ const KEY = {
   PAGEUP: 'PageUp'
 }
 const AJAX_DEBOUNCE = 500
-const ARIA_LIVE_DELAY = 150 // 150 ms established as sufficient, through testing, to not be invasive of expected screen-reader behavior
+const ARIA_LIVE_DELAY = 200 // 200 ms established as sufficient, through testing, to not be invasive of expected screen-reader behavior
 const ARIA_LIVE_VISIBLE = 'Forslag vises'
 const ARIA_LIVE_FILTERED = 'Ingen forslag'
 const ARIA_LIVE_COUNT = '{{value}} forslag'

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -14,8 +14,8 @@ const KEY = {
   PAGEUP: 'PageUp'
 }
 const AJAX_DEBOUNCE = 500
-const ARIA_LIVE_DELAY = 100 // 100 ms established as sufficient, through testing.
-const ARIA_LIVE_FILTERED = 'Ingen forslag'
+const ARIA_LIVE_DELAY = 300 // 300 ms established as sufficient, through testing, for messages to register properly in sr-queue and also support longer label/placeholder-combos.
+const ARIA_LIVE_FILTERED = 'Ingen forslag vises'
 const ARIA_LIVE_COUNT = '{{value}} forslag vises'
 
 export default class CoreSuggest extends HTMLElement {

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -14,7 +14,7 @@ const KEY = {
   PAGEUP: 'PageUp'
 }
 const AJAX_DEBOUNCE = 500
-const ARIA_LIVE_DELAY = 200 // 200 ms established as sufficient, through testing, to not be invasive of expected screen-reader behavior
+const ARIA_LIVE_DELAY = 100 // 100 ms established as sufficient, through testing.
 const ARIA_LIVE_FILTERED = 'Ingen forslag'
 const ARIA_LIVE_COUNT = '{{value}} forslag'
 

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -274,7 +274,7 @@ function onMutation (self) {
  * @returns {void}
  */
 function onInput (self, event) {
-  if (event.target !== self.input || !dispatchEvent(self, 'suggest.filter') || onAjax(self) || self.hasAttribute('filter-disabled')) return
+  if (event.target !== self.input || !dispatchEvent(self, 'suggest.filter') || onAjax(self)) return
   const value = self.input.value.toLowerCase()
   const items = self.querySelectorAll('a,button')
 

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -62,7 +62,7 @@ export default class CoreSuggest extends HTMLElement {
       if (!this.empty && !this.hidden) {
         // Clear if there is an existing delay
         if (this._ariaLiveDelay) clearTimeout(this._ariaLiveDelay)
-        this._ariaLiveDelay = setTimeout(() => notifyResultsVisible(this, this.hidden), ARIA_LIVE_DELAY)
+        this._ariaLiveDelay = setTimeout(() => notifyResultsVisible(this), ARIA_LIVE_DELAY)
       }
     }
     if (name === 'highlight') onMutation(this)
@@ -154,21 +154,15 @@ function appendResultsNotificationSpan (self) {
 
 /**
  * Notify screen readers when results are visible
- * textContent uses attribute `'live-region-label'` or defaults to `'Søkeresultater vises'`
+ * textContent uses attribute `'live-region-shown-label'`
  *
  * @param {CoreSuggest} self Core suggest element
- * @param {Boolean} clear defaults to false. Flag to remove textContent of existing node
  * @returns {void}
  */
-function notifyResultsVisible (self, clear = false) {
+function notifyResultsVisible (self) {
   if (!self._observer) return // Abort if disconnectedCallback has been called
-
-  if (clear) {
-    self._clearLiveRegion()
-  } else {
-    const label = self.getAttribute('live-region-label') || 'Søkeresultater vises'
-    self._pushToLiveRegion(label)
-  }
+  const label = self.getAttribute('live-region-shown-label')
+  self._pushToLiveRegion(label)
 }
 
 /**

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -15,6 +15,8 @@ const KEY = {
 }
 const AJAX_DEBOUNCE = 500
 const ARIA_LIVE_DELAY = 150 // 150 ms established as sufficient, through testing, to not be invasive of expected screen-reader behavior
+const ARIA_LIVE_VISIBLE = 'Forslag vises'
+const ARIA_LIVE_FILTERED = 'Ingen forslag'
 
 export default class CoreSuggest extends HTMLElement {
   static get observedAttributes () { return ['hidden', 'highlight', 'empty'] }
@@ -162,7 +164,8 @@ function appendResultsNotificationSpan (self) {
 function notifyResultsVisible (self) {
   if (!self._observer) return // Abort if disconnectedCallback has been called
   const label = self.getAttribute('live-region-shown-label')
-  self._pushToLiveRegion(label)
+  if (label === '') return // Abort if label is set to explicit empty string
+  self._pushToLiveRegion(label || ARIA_LIVE_VISIBLE)
 }
 
 /**
@@ -263,7 +266,8 @@ function onInput (self, event) {
     if (visibleItems && visibleItems.length === 0) {
       // All items have been hidden by filter
       const label = self.getAttribute('live-region-empty-label')
-      self._pushToLiveRegion(label)
+      if (label === '') return // Abort if label is set to explicit empty string
+      self._pushToLiveRegion(label || ARIA_LIVE_FILTERED)
     }
   }
 }

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -147,21 +147,21 @@ function appendResultsNotificationSpan (self) {
 
 /**
  * Notify screen readers when results are visible
- * textContent uses attribute `'live-region-shown-label'`
+ * textContent uses attribute `'data-sr-shown-message'`
  *
  * @param {CoreSuggest} self Core suggest element
  * @returns {void}
  */
 function notifyResultsVisible (self) {
   if (!self._observer) return // Abort if disconnectedCallback has been called
-  const label = self.getAttribute('live-region-shown-label')
+  const label = self.getAttribute('data-sr-shown-message')
   if (label === '') return // Abort if label is set to explicit empty string
   self._pushToLiveRegion(label || ARIA_LIVE_VISIBLE)
 }
 
 /**
  * Notify screen readers how many results are visible
- * textContent uses attribute `'live-region-count-label'`
+ * textContent uses attribute `'data-sr-count-message'`
  * Replaces `{{value}}` with number of visible items
  *
  * @param {CoreSuggest} self Core suggest element
@@ -170,21 +170,21 @@ function notifyResultsVisible (self) {
  */
 function notifyResultCount (self, items = 0) {
   if (!self._observer) return // Abort if disconnectedCallback has been called
-  const label = self.getAttribute('live-region-count-label')
+  const label = self.getAttribute('data-sr-count-message')
   if (label === '') return // Abort if label is set to explicit empty string
   self._pushToLiveRegion((label || ARIA_LIVE_COUNT).replace('{{value}}', items))
 }
 
 /**
  * Notify screen readers when all results are hidden by filter
- * textContent uses attribute `'live-region-empty-label'`
+ * textContent uses attribute `'data-sr-empty-message'`
  *
  * @param {CoreSuggest} self Core suggest element
  * @returns {void}
  */
 function notifyResultsEmpty (self) {
   if (!self._observer) return // Abort if disconnectedCallback has been called
-  const label = self.getAttribute('live-region-empty-label')
+  const label = self.getAttribute('data-sr-empty-message')
   if (label === '') return // Abort if label is set to explicit empty string
   self._pushToLiveRegion(label || ARIA_LIVE_FILTERED)
 }

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -52,6 +52,7 @@ export default class CoreSuggest extends HTMLElement {
     // Clear internals to aid garbage collection
     this._observer.disconnect()
     clearTimeout(this._ariaLiveTimeout) // Clear existing timeout
+    if (this._ariaLiveSpan.parentNode) this._ariaLiveSpan.parentNode.removeChild(this._ariaLiveSpan)
     this._observer = this._input = this._regex = this._xhr = this._xhrTime = this._ariaLiveDelay = this._ariaLiveTimeout = this._ariaLiveSpan = null
   }
 
@@ -129,9 +130,9 @@ export default class CoreSuggest extends HTMLElement {
  * @returns {HTMLSpanElement}
  */
 function appendResultsNotificationSpan (self) {
-  if (!self._observer) return // Abort if disconnectedCallback has been called
-  self.insertAdjacentHTML('beforeend', '<span aria-live="polite" style="position: absolute !important; overflow: hidden !important; width: 1px !important; height: 1px !important; clip: rect(0, 0, 0, 0) !important"></span>')
-  return self.lastElementChild
+  if (!self._observer || self._ariaLiveSpan) return // Abort if disconnectedCallback has been called
+  document.body.insertAdjacentHTML('beforeend', '<span aria-live="polite" style="position: absolute !important; overflow: hidden !important; width: 1px !important; height: 1px !important; clip: rect(0, 0, 0, 0) !important"></span>')
+  return document.body.lastElementChild
 }
 
 /**

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -24,7 +24,7 @@ export default class CoreSuggest extends HTMLElement {
 
   connectedCallback () {
     this._observer = new window.MutationObserver(mutationsList => onMutation(this, mutationsList))
-    this._observer.observe(this, { subtree: true, childList: true, attributes: true, attributeFilter: ['hidden'], attributeOldValue: true })
+    this._observer.observe(this, { subtree: true, childList: true, attributes: true, attributeFilter: ['hidden'] })
     this._xhr = new window.XMLHttpRequest()
     this.id = this.id || getUUID()
 
@@ -260,18 +260,18 @@ function onMutation (self, mutations) {
     for (const mutation of mutations) {
       if (mutation.attributeName === 'hidden') {
         if (mutation.target === self) {
-          if (mutation.oldValue === '' && !self._empty) {
+          if (!self.hidden && !self._empty) {
             // Notify screen readers when visible and list has content
             clearTimeout(self._ariaLiveDelay) // Clear existing delay
             self._ariaLiveDelay = setTimeout(() => notifyResultsVisible(self, items.length), ARIA_LIVE_DELAY)
             break // Break loop to avoid duplicate messages
           }
         } else {
-          if (mutation.oldValue === null && self._empty) {
+          if (self._empty) {
             // Notify screen readers when suggestions are completely hidden by filter
             notifyResultsEmpty(self)
             break // Break loop to avoid duplicate messages
-          } else if (!self._empty) {
+          } else {
             // Notify screen readers when number of suggestions are modified by filter
             notifyResultCount(self, items.length)
             break // Break loop to avoid duplicate messages

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -47,14 +47,15 @@ export default class CoreSuggest extends HTMLElement {
     // Clear internals to aid garbage collection
     this._observer.disconnect()
     if (this._ariaLiveTimeout) clearTimeout(this._ariaLiveTimeout) // Clear existing timeout
-    this._observer = this._input = this._regex = this._xhr = this._xhrTime = this._ariaLiveTimeout = this._ariaLiveSpan = null
+    this._observer = this._input = this._regex = this._xhr = this._xhrTime = this._ariaLiveDelay = this._ariaLiveTimeout = this._ariaLiveSpan = null
   }
 
   attributeChangedCallback (name, prev, next) {
     if (!this._observer) return
     if (name === 'hidden') {
       this.input.setAttribute('aria-expanded', !this.hidden)
-      setTimeout(() => notifyResultsVisible(this, this.hidden), ARIA_LIVE_DELAY)
+      if (this._ariaLiveDelay) clearTimeout(this._ariaLiveDelay)
+      this._ariaLiveDelay = setTimeout(() => notifyResultsVisible(this, this.hidden), ARIA_LIVE_DELAY)
     }
     if (name === 'highlight') onMutation(this)
   }

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -201,7 +201,7 @@ function onMutation (self) {
     }
   }
 
-  self.empty = items.length < 1
+  self.empty = items.length === 0
 
   for (let i = 0, l = items.length; i < l; ++i) {
     items[i].setAttribute('aria-label', `${items[i].textContent}, ${i + 1} av ${limit}`)

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -358,6 +358,8 @@ function onAjaxSend (self) {
         self._xhr.responseError = error.toString()
         dispatchEvent(self, 'suggest.ajax.error', self._xhr)
       }
+      // Data successfully received
+      notifyResultsVisible(self)
       dispatchEvent(self, 'suggest.ajax', self._xhr)
     }
     self._xhr.open('GET', self.ajax.replace('{{value}}', window.encodeURIComponent(self.input.value)), true)

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -140,13 +140,14 @@ function appendResultsNotificationSpan (self) {
  * textContent uses attribute `'data-sr-shown-message'`
  *
  * @param {CoreSuggest} self Core suggest element
+ * @param {Number} items Number of visible items
  * @returns {void}
  */
-function notifyResultsVisible (self) {
+function notifyResultsVisible (self, items) {
   if (!self._observer) return // Abort if disconnectedCallback has been called
   const label = self.getAttribute('data-sr-shown-message')
   if (label === '') return // Abort if label is set to explicit empty string
-  self._pushToLiveRegion(label || ARIA_LIVE_VISIBLE)
+  self._pushToLiveRegion((label || ARIA_LIVE_VISIBLE).replace('{{value}}', items))
 }
 
 /**

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -17,7 +17,7 @@ const AJAX_DEBOUNCE = 500
 const ARIA_LIVE_DELAY = 150 // 150 ms established as sufficient, through testing, to not be invasive of expected screen-reader behavior
 
 export default class CoreSuggest extends HTMLElement {
-  static get observedAttributes () { return ['hidden', 'highlight'] }
+  static get observedAttributes () { return ['hidden', 'highlight', 'empty'] }
 
   connectedCallback () {
     this._observer = new window.MutationObserver(() => onMutation(this)) // Enhance <a> and <button> markup
@@ -121,6 +121,10 @@ export default class CoreSuggest extends HTMLElement {
   get hidden () { return this.hasAttribute('hidden') }
 
   set hidden (val) { toggleAttribute(this, 'hidden', val) }
+
+  get empty () { return this.hasAttribute('empty') }
+
+  set empty (val) { toggleAttribute(this, 'empty', val) }
 }
 
 /**
@@ -196,6 +200,8 @@ function onMutation (self) {
       parent.normalize && parent.normalize()
     }
   }
+
+  self.empty = items.length < 1
 
   for (let i = 0, l = items.length; i < l; ++i) {
     items[i].setAttribute('aria-label', `${items[i].textContent}, ${i + 1} av ${limit}`)

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -51,7 +51,7 @@ export default class CoreSuggest extends HTMLElement {
     document.removeEventListener('focusin', this)
     // Clear internals to aid garbage collection
     this._observer.disconnect()
-    if (this._ariaLiveTimeout) clearTimeout(this._ariaLiveTimeout) // Clear existing timeout
+    clearTimeout(this._ariaLiveTimeout) // Clear existing timeout
     this._observer = this._input = this._regex = this._xhr = this._xhrTime = this._ariaLiveDelay = this._ariaLiveTimeout = this._ariaLiveSpan = null
   }
 
@@ -63,8 +63,7 @@ export default class CoreSuggest extends HTMLElement {
     if (name === 'empty' || name === 'hidden') {
       // Notify screen readers when visible and list has content
       if (!this.empty && !this.hidden) {
-        // Clear if there is an existing delay
-        if (this._ariaLiveDelay) clearTimeout(this._ariaLiveDelay)
+        clearTimeout(this._ariaLiveDelay) // Clear existing delay
         this._ariaLiveDelay = setTimeout(() => notifyResultsVisible(this), ARIA_LIVE_DELAY)
       }
     }
@@ -85,7 +84,7 @@ export default class CoreSuggest extends HTMLElement {
   escapeHTML (str) { return escapeHTML(str) }
 
   _clearLiveRegion () {
-    if (this._ariaLiveTimeout) clearTimeout(this._ariaLiveTimeout) // Clear existing timeout
+    clearTimeout(this._ariaLiveTimeout) // Clear existing timeout
     this._ariaLiveSpan.textContent = ''
   }
 
@@ -95,7 +94,7 @@ export default class CoreSuggest extends HTMLElement {
    */
   _pushToLiveRegion (label) {
     if (this._ariaLiveSpan.textContent === label) return // Abort duplicates
-    if (this._ariaLiveTimeout) clearTimeout(this._ariaLiveTimeout) // Clear existing timeout
+    clearTimeout(this._ariaLiveTimeout) // Clear existing timeout
     this._ariaLiveSpan.textContent = label
     this._ariaLiveTimeout = setTimeout(() => (this._clearLiveRegion()), ARIA_LIVE_DELAY)
   }

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -158,7 +158,7 @@ function notifyResultsVisible (self, items) {
  * @param {Number} items Number of visible items
  * @returns {void}
  */
-function notifyResultCount (self, items = 0) {
+function notifyResultCount (self, items) {
   if (!self._observer) return // Abort if disconnectedCallback has been called
   const label = self.getAttribute('data-sr-count-message')
   if (label === '') return // Abort if label is set to explicit empty string
@@ -263,17 +263,17 @@ function onMutation (self, mutations) {
             // Notify screen readers when visible and list has content
             clearTimeout(self._ariaLiveDelay) // Clear existing delay
             self._ariaLiveDelay = setTimeout(() => notifyResultsVisible(self, items.length), ARIA_LIVE_DELAY)
-            break // Break loop to avoid duplicate messages
+            break // Avoid duplicate messages
           }
         } else {
           if (self._empty) {
             // Notify screen readers when suggestions are completely hidden by filter
             notifyResultsEmpty(self)
-            break // Break loop to avoid duplicate messages
+            break // Avoid duplicate messages
           } else {
             // Notify screen readers when number of suggestions are modified by filter
             notifyResultCount(self, items.length)
-            break // Break loop to avoid duplicate messages
+            break // Avoid duplicate messages
           }
         }
       } else if (mutation.type === 'childList') {
@@ -281,7 +281,7 @@ function onMutation (self, mutations) {
           // Notify screen readers when visible and list has inserted content
           clearTimeout(self._ariaLiveDelay) // Clear existing delay
           self._ariaLiveDelay = setTimeout(() => notifyResultsVisible(self, items.length), ARIA_LIVE_DELAY)
-          break
+          break // Avoid duplicate messages
         }
       }
     }

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -254,11 +254,11 @@ function onMutation (self) {
   }
 
   // Send messages for screen readers
-  const hasNoInteractibleItems = !self.querySelector('a,button')
-  const isNoSearchYet = hasNoInteractibleItems && !self.input.value
-  const textContent = hasNoInteractibleItems && self.textContent.trim()
+  const hasNoItems = !self.querySelector('a,button') // Accounts for hidden as well
+  const hasNotSearchedYet = hasNoItems && !self.input.value
+  const textContent = hasNoItems && self.textContent.trim()
 
-  if (self.hidden || isNoSearchYet) self._clearLiveRegion()
+  if (self.hidden || hasNotSearchedYet) self._clearLiveRegion()
   else if (textContent) notifyTextContent(self, textContent)
   else if (items.length) notifyResultCount(self, items.length)
   else notifyResultsEmpty(self)

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -257,6 +257,15 @@ function onInput (self, event) {
   for (let i = 0, l = items.length; i < l; ++i) {
     toggleItem(items[i], (items[i].value || items[i].textContent).toLowerCase().indexOf(value) === -1)
   }
+
+  if (items.length > 0) {
+    const visibleItems = queryAll('[tabindex="-1"]:not([hidden])', self)
+    if (visibleItems && visibleItems.length === 0) {
+      // All items have been hidden by filter
+      const label = self.getAttribute('live-region-empty-label')
+      self._pushToLiveRegion(label)
+    }
+  }
 }
 
 /**

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -1,4 +1,4 @@
-import { closest, dispatchEvent, escapeHTML, IS_IE11, IS_IOS, queryAll, toggleAttribute } from '../utils'
+import { closest, dispatchEvent, escapeHTML, getUUID, IS_IE11, IS_IOS, queryAll, toggleAttribute } from '../utils'
 
 const KEY = {
   DOWN_IE: 'Down',
@@ -23,11 +23,13 @@ export default class CoreSuggest extends HTMLElement {
     this._observer = new window.MutationObserver(() => onMutation(this)) // Enhance <a> and <button> markup
     this._observer.observe(this, { subtree: true, childList: true, attributes: true, attributeFilter: ['hidden'] })
     this._xhr = new window.XMLHttpRequest()
+    this._id = this.getAttribute('id') ? this.getAttribute('id') : getUUID()
 
     if (IS_IOS) this.input.setAttribute('role', 'combobox') // iOS does not inform about editability if combobox
     this.input.setAttribute('autocomplete', 'off')
     this.input.setAttribute('aria-autocomplete', 'list')
     this.input.setAttribute('aria-expanded', false)
+    this.input.setAttribute('aria-controls', this._id)
 
     this._ariaLiveSpan = appendResultsNotificationSpan(this)
 

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -79,7 +79,7 @@ export default class CoreSuggest extends HTMLElement {
 
   _clearLiveRegion () {
     clearTimeout(this._ariaLiveTimeout) // Clear existing timeout
-    this._ariaLiveSpan.textContent = ''
+    this._ariaLiveSpan.textContent = null
   }
 
   /**

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -242,7 +242,7 @@ function onMutation (self) {
  * @returns {void}
  */
 function onInput (self, event) {
-  if (event.target !== self.input || !dispatchEvent(self, 'suggest.filter') || onAjax(self)) return
+  if (event.target !== self.input || !dispatchEvent(self, 'suggest.filter') || onAjax(self) || self.hasAttribute('filter-disabled')) return
   const value = self.input.value.toLowerCase()
   const items = self.querySelectorAll('a,button')
 

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -194,7 +194,7 @@ function toggleItem (item, show) {
  * Enhances items with aria-label, tabindex and type="button"
  * Respects limit attribute
  * Updates <mark> tags for highlighting according to attribute
- * Trigger messages for screen-readers
+ * Trigger messages for screen readers
  * This can happen quite frequently so make it fast
  * @param {CoreSuggest} self Core suggest element
  * @returns {void}

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -86,7 +86,7 @@ export default class CoreSuggest extends HTMLElement {
    * @param {String} label
    * @returns {void}
    */
-  _pushToLiveRegion (label) {
+  pushToLiveRegion (label) {
     if (this._ariaLiveSpan.textContent === label) return // Abort duplicates
     clearTimeout(this._ariaLiveTimeout) // Clear existing timeout
     this._ariaLiveSpan.textContent = label
@@ -147,7 +147,7 @@ function notifyResultsVisible (self, items) {
   if (!self._observer) return // Abort if disconnectedCallback has been called
   const label = self.getAttribute('data-sr-shown-message')
   if (label === '') return // Abort if label is set to explicit empty string
-  self._pushToLiveRegion((label || ARIA_LIVE_VISIBLE).replace('{{value}}', items))
+  self.pushToLiveRegion((label || ARIA_LIVE_VISIBLE).replace('{{value}}', items))
 }
 
 /**
@@ -163,7 +163,7 @@ function notifyResultCount (self, items = 0) {
   if (!self._observer) return // Abort if disconnectedCallback has been called
   const label = self.getAttribute('data-sr-count-message')
   if (label === '') return // Abort if label is set to explicit empty string
-  self._pushToLiveRegion((label || ARIA_LIVE_COUNT).replace('{{value}}', items))
+  self.pushToLiveRegion((label || ARIA_LIVE_COUNT).replace('{{value}}', items))
 }
 
 /**
@@ -177,7 +177,7 @@ function notifyResultsEmpty (self) {
   if (!self._observer) return // Abort if disconnectedCallback has been called
   const label = self.getAttribute('data-sr-empty-message')
   if (label === '') return // Abort if label is set to explicit empty string
-  self._pushToLiveRegion(label || ARIA_LIVE_FILTERED)
+  self.pushToLiveRegion(label || ARIA_LIVE_FILTERED)
 }
 
 /**

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -1,4 +1,4 @@
-import { closest, dispatchEvent, escapeHTML, getUUID, IS_IE11, IS_IOS, queryAll, toggleAttribute } from '../utils'
+import { closest, dispatchEvent, escapeHTML, getUUID, IS_IE11, queryAll, toggleAttribute } from '../utils'
 
 const KEY = {
   DOWN_IE: 'Down',
@@ -28,7 +28,7 @@ export default class CoreSuggest extends HTMLElement {
     this._xhr = new window.XMLHttpRequest()
     this.id = this.id || getUUID()
 
-    if (IS_IOS) this.input.setAttribute('role', 'combobox') // iOS does not inform about editability if combobox
+    this.input.setAttribute('role', 'combobox')
     this.input.setAttribute('autocomplete', 'off')
     this.input.setAttribute('aria-autocomplete', 'list')
     this.input.setAttribute('aria-expanded', false)

--- a/packages/core-suggest/core-suggest.test.js
+++ b/packages/core-suggest/core-suggest.test.js
@@ -311,14 +311,14 @@ describe('core-suggest', () => {
   })
 
   describe('aria-live', () => {
-    it('creates an empty span with aria-live="polite"', async () => {
+    it('creates an empty span on body with aria-live="polite"', async () => {
       await browser.executeScript(() => {
         document.body.innerHTML = `
           <input type="text">
           <core-suggest hidden></core-suggest>
         `
       })
-      await expect(attr('core-suggest > span', 'aria-live')).toEqual('polite')
+      await expect(attr('body > span', 'aria-live')).toEqual('polite')
     })
 
     it('exposes internal function _pushToLiveRegion to append, then clear textContent of aria-live region', async () => {
@@ -331,9 +331,9 @@ describe('core-suggest', () => {
         `
         document.querySelector('core-suggest')._pushToLiveRegion(label)
       }, testLabel)
-      await expect(browser.executeScript(() => document.querySelector('core-suggest > span').textContent)).toEqual(testLabel)
+      await expect(browser.executeScript(() => document.querySelector('body > span').textContent)).toEqual(testLabel)
       await browser.sleep(ARIA_LIVE_DELAY)
-      await expect(browser.executeScript(() => document.querySelector('core-suggest > span').textContent)).toEqual('')
+      await expect(browser.executeScript(() => document.querySelector('body > span').textContent)).toEqual('')
     })
 
     it('exposes internal function _clearLiveRegion to clear textContent of aria-live region', async () => {
@@ -346,7 +346,7 @@ describe('core-suggest', () => {
         document.querySelector('core-suggest')._pushToLiveRegion(label)
         document.querySelector('core-suggest')._clearLiveRegion()
       }, testLabel)
-      await expect(browser.executeScript(() => document.querySelector('core-suggest > span').textContent)).toEqual('')
+      await expect(browser.executeScript(() => document.querySelector('body > span').textContent)).toEqual('')
     })
   })
 })

--- a/packages/core-suggest/core-suggest.test.js
+++ b/packages/core-suggest/core-suggest.test.js
@@ -323,7 +323,7 @@ describe('core-suggest', () => {
 
     it('exposes internal function pushToLiveRegion to append, then clear textContent of aria-live region', async () => {
       const testLabel = 'TEST'
-      const ARIA_LIVE_DELAY = 200 // Mirror ARIA_LIVE_DELAY of 200 ms
+      const ARIA_LIVE_DELAY = 300 // Mirror ARIA_LIVE_DELAY of 300 ms
       await browser.executeScript((label) => {
         document.body.innerHTML = `
           <input type="text">
@@ -331,8 +331,9 @@ describe('core-suggest', () => {
         `
         document.querySelector('core-suggest').pushToLiveRegion(label)
       }, testLabel)
+      await browser.sleep(ARIA_LIVE_DELAY) // Wait out delay for textContent to be updated
       await expect(browser.executeScript(() => document.querySelector('body > span').textContent)).toEqual(testLabel)
-      await browser.sleep(ARIA_LIVE_DELAY)
+      await browser.sleep(ARIA_LIVE_DELAY) // Wait out delay for textContent to be cleared
       await expect(browser.executeScript(() => document.querySelector('body > span').textContent)).toEqual('')
     })
 

--- a/packages/core-suggest/core-suggest.test.js
+++ b/packages/core-suggest/core-suggest.test.js
@@ -321,15 +321,15 @@ describe('core-suggest', () => {
       await expect(attr('body > span', 'aria-live')).toEqual('polite')
     })
 
-    it('exposes internal function _pushToLiveRegion to append, then clear textContent of aria-live region', async () => {
+    it('exposes internal function pushToLiveRegion to append, then clear textContent of aria-live region', async () => {
       const testLabel = 'TEST'
-      const ARIA_LIVE_DELAY = 150 // Mirror ARIA_LIVE_DELAY of 150 ms
+      const ARIA_LIVE_DELAY = 200 // Mirror ARIA_LIVE_DELAY of 200 ms
       await browser.executeScript((label) => {
         document.body.innerHTML = `
           <input type="text">
           <core-suggest hidden></core-suggest>
         `
-        document.querySelector('core-suggest')._pushToLiveRegion(label)
+        document.querySelector('core-suggest').pushToLiveRegion(label)
       }, testLabel)
       await expect(browser.executeScript(() => document.querySelector('body > span').textContent)).toEqual(testLabel)
       await browser.sleep(ARIA_LIVE_DELAY)
@@ -343,7 +343,7 @@ describe('core-suggest', () => {
           <input type="text">
           <core-suggest hidden></core-suggest>
         `
-        document.querySelector('core-suggest')._pushToLiveRegion(label)
+        document.querySelector('core-suggest').pushToLiveRegion(label)
         document.querySelector('core-suggest')._clearLiveRegion()
       }, testLabel)
       await expect(browser.executeScript(() => document.querySelector('body > span').textContent)).toEqual('')

--- a/packages/core-suggest/core-suggest.test.js
+++ b/packages/core-suggest/core-suggest.test.js
@@ -309,4 +309,44 @@ describe('core-suggest', () => {
     const text = await browser.wait(() => browser.executeScript(() => window.response))
     await expect(text).toEqual(TEST_BAD_JSON_RESPONSE)
   })
+
+  describe('aria-live', () => {
+    it('creates an empty span with aria-live="polite"', async () => {
+      await browser.executeScript(() => {
+        document.body.innerHTML = `
+          <input type="text">
+          <core-suggest hidden></core-suggest>
+        `
+      })
+      await expect(attr('core-suggest > span', 'aria-live')).toEqual('polite')
+    })
+
+    it('exposes internal function _pushToLiveRegion to append, then clear textContent of aria-live region', async () => {
+      const testLabel = 'TEST'
+      const ARIA_LIVE_DELAY = 150 // Mirror ARIA_LIVE_DELAY of 150 ms
+      await browser.executeScript((label) => {
+        document.body.innerHTML = `
+          <input type="text">
+          <core-suggest hidden></core-suggest>
+        `
+        document.querySelector('core-suggest')._pushToLiveRegion(label)
+      }, testLabel)
+      await expect(browser.executeScript(() => document.querySelector('core-suggest > span').textContent)).toEqual(testLabel)
+      await browser.sleep(ARIA_LIVE_DELAY)
+      await expect(browser.executeScript(() => document.querySelector('core-suggest > span').textContent)).toEqual('')
+    })
+
+    it('exposes internal function _clearLiveRegion to clear textContent of aria-live region', async () => {
+      const testLabel = 'TEST'
+      await browser.executeScript((label) => {
+        document.body.innerHTML = `
+          <input type="text">
+          <core-suggest hidden></core-suggest>
+        `
+        document.querySelector('core-suggest')._pushToLiveRegion(label)
+        document.querySelector('core-suggest')._clearLiveRegion()
+      }, testLabel)
+      await expect(browser.executeScript(() => document.querySelector('core-suggest > span').textContent)).toEqual('')
+    })
+  })
 })

--- a/packages/core-suggest/core-suggest.test.js
+++ b/packages/core-suggest/core-suggest.test.js
@@ -336,18 +336,5 @@ describe('core-suggest', () => {
       await browser.sleep(ARIA_LIVE_DELAY) // Wait out delay for textContent to be cleared
       await expect(browser.executeScript(() => document.querySelector('body > span').textContent)).toEqual('')
     })
-
-    it('exposes internal function _clearLiveRegion to clear textContent of aria-live region', async () => {
-      const testLabel = 'TEST'
-      await browser.executeScript((label) => {
-        document.body.innerHTML = `
-          <input type="text">
-          <core-suggest hidden></core-suggest>
-        `
-        document.querySelector('core-suggest').pushToLiveRegion(label)
-        document.querySelector('core-suggest')._clearLiveRegion()
-      }, testLabel)
-      await expect(browser.executeScript(() => document.querySelector('body > span').textContent)).toEqual('')
-    })
   })
 })

--- a/packages/core-suggest/readme.md
+++ b/packages/core-suggest/readme.md
@@ -13,6 +13,11 @@
 <style>
 li button:focus {outline: 3px solid rgb(94, 158, 215)}
 label {display: block}
+.table-wrapper { overflow-x: auto; margin-bottom: 1.5rem; width: 100%; }
+.table-wrapper table { border-collapse: collapse; }
+.table-wrapper table caption { text-align: left; font-weight: bold; }
+.table-wrapper table th { padding: .5em .5em; font-weight: 600; text-align: center; border: 1px solid #0f0f0f; }
+.table-wrapper table td { padding: .5em .5em; text-align: center; border: 1px solid #0f0f0f; }
 </style>
 demo-->
 
@@ -604,6 +609,202 @@ All styling in documentation is example only. Both the `<button>` and content el
 .my-input-content mark {}             /* Target highlighted text (use `highlight='off'` to disable highlighting) */
 ```
 
+## Notes on accessibility
+
+### Screen reader notifications
+
+Release 1.3.0 introduced screen reader notifications for the following scenarios:
+ - Suggestions become visible to the user, message defaults to `Forslag vises`.
+ - The number of suggestions are announced when it changes, message defaults to `{{value}} forslag`.
+ - When no suggestions remain, message defaults to `Ingen forslag`.
+
+Norwegian language is used by default, but the content can be changed by setting the appropriate [attributes](#aria-live)
+
+These notifications have been added to improve the user experience when using screen readers and to comply with [WCAG 2.1 4.1.3](https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html), in-depth information available from [uutilsynet](https://www.uutilsynet.no/wcag-standarden/413-statusbeskjeder-niva-aa/152)
+
+As part of verifying compatibility with various screen-readers we made the following observations:
+
+* When using NVDA, JAWS or Narrator on Windows, notification when visible (`Forslag vises`) is superfluous as `aria-expanded` conveyes that the content is expanded. It is kept in for broader support across platforms.
+* 
+
+Using JAWS version 2022-04 on windows 10, NVDA version 2021.3.5 on windows 10, Narrator on windows 10, TalkBack on EMUI 100
+Testing resuls as of `2022-05-10`:
+
+
+<div class="table-wrapper" tabindex="0">
+<table>
+  <caption>Screen reader is notified when suggestions become visible to the user</caption>
+  <colgroup span="3"></colgroup>
+  <colgroup span="2"></colgroup>
+  <colgroup span="3"></colgroup>
+  <colgroup span="1"></colgroup>
+  <colgroup span="1"></colgroup>
+  <colgroup span="2"></colgroup>
+  <colgroup span="2"></colgroup>
+  <tbody>
+    <tr>
+      <th colspan="3" scope="colgroup">JAWS</th>
+      <th colspan="2" scope="colgroup">Narrator</th>
+      <th colspan="3" scope="colgroup">NVDA</th>
+      <th colspan="1" scope="colgroup">Orca</th>
+      <th colspan="1" scope="colgroup">TalkBack</th>
+      <th colspan="2" scope="colgroup">VoiceOver (iOS)</th>
+      <th colspan="2" scope="colgroup">VoiceOver (macOS)</th>
+    </tr>
+    <tr>
+      <th scope="col">Chrome</th>
+      <th scope="col">Edge</th>
+      <th scope="col">Firefox</th>
+      <th scope="col">Chrome</th>
+      <th scope="col">Edge</th>
+      <th scope="col">Chrome</th>
+      <th scope="col">Edge</th>
+      <th scope="col">Firefox</th>
+      <th scope="col">Firefox</th>
+      <th scope="col">Chrome</th>
+      <th scope="col">Safari</th>
+      <th scope="col">Chrome</th>
+      <th scope="col">Safari</th>
+      <th scope="col">Chrome</th>
+    </tr>
+    <tr>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Partial *</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Partial *</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+`*` JAWS and Orca on Firefox will not always relay visible suggestions, but is covered by `aria-expanded`.
+
+<div class="table-wrapper" tabindex="0">
+<table>
+  <caption>Screen reader is notified when the number of suggestions changes</caption>
+  <colgroup span="3"></colgroup>
+  <colgroup span="2"></colgroup>
+  <colgroup span="3"></colgroup>
+  <colgroup span="1"></colgroup>
+  <colgroup span="1"></colgroup>
+  <colgroup span="2"></colgroup>
+  <colgroup span="2"></colgroup>
+  <tbody>
+    <tr>
+      <th colspan="3" scope="colgroup">JAWS</th>
+      <th colspan="2" scope="colgroup">Narrator</th>
+      <th colspan="3" scope="colgroup">NVDA</th>
+      <th colspan="1" scope="colgroup">Orca</th>
+      <th colspan="1" scope="colgroup">TalkBack</th>
+      <th colspan="2" scope="colgroup">VoiceOver (iOS)</th>
+      <th colspan="2" scope="colgroup">VoiceOver (macOS)</th>
+    </tr>
+    <tr>
+      <th scope="col">Chrome</th>
+      <th scope="col">Edge</th>
+      <th scope="col">Firefox</th>
+      <th scope="col">Chrome</th>
+      <th scope="col">Edge</th>
+      <th scope="col">Chrome</th>
+      <th scope="col">Edge</th>
+      <th scope="col">Firefox</th>
+      <th scope="col">Firefox</th>
+      <th scope="col">Chrome</th>
+      <th scope="col">Safari</th>
+      <th scope="col">Chrome</th>
+      <th scope="col">Safari</th>
+      <th scope="col">Chrome</th>
+    </tr>
+    <tr>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Partial *</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Partial **</td>
+      <td>Supported</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+`*` JAWS on Firefox will sometimes not read number of suggestions until you remove characters
+
+`**` Voiceover on Safari will sometimes stop relaying updates to number of suggestions.
+
+<div class="table-wrapper" tabindex="0">
+<table>
+  <caption>Screen reader is notified when no suggestions remain</caption>
+  <colgroup span="3"></colgroup>
+  <colgroup span="2"></colgroup>
+  <colgroup span="3"></colgroup>
+  <colgroup span="1"></colgroup>
+  <colgroup span="1"></colgroup>
+  <colgroup span="2"></colgroup>
+  <colgroup span="2"></colgroup>
+  <tbody>
+    <tr>
+      <th colspan="3" scope="colgroup">JAWS</th>
+      <th colspan="2" scope="colgroup">Narrator</th>
+      <th colspan="3" scope="colgroup">NVDA</th>
+      <th colspan="1" scope="colgroup">Orca</th>
+      <th colspan="1" scope="colgroup">TalkBack</th>
+      <th colspan="2" scope="colgroup">VoiceOver (iOS)</th>
+      <th colspan="2" scope="colgroup">VoiceOver (macOS)</th>
+    </tr>
+    <tr>
+      <th scope="col">Chrome</th>
+      <th scope="col">Edge</th>
+      <th scope="col">Firefox</th>
+      <th scope="col">Chrome</th>
+      <th scope="col">Edge</th>
+      <th scope="col">Chrome</th>
+      <th scope="col">Edge</th>
+      <th scope="col">Firefox</th>
+      <th scope="col">Firefox</th>
+      <th scope="col">Chrome</th>
+      <th scope="col">Safari</th>
+      <th scope="col">Chrome</th>
+      <th scope="col">Safari</th>
+      <th scope="col">Chrome</th>
+    </tr>
+    <tr>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
 ## FAQ
 
 ### Why not use `<datalist>` instead?
@@ -617,7 +818,8 @@ Despite well documented [examples in the aria 1.1 spesification](https://www.w3.
 - `role="listbox"` - VoiceOver needs aria-selected to falsely announce "0 selected"</li>
 - `role="option"` - falsely announces links and buttons as "text"</li>
 - `aria-live="assertive"` - fails to correctly inform user if current target is link or button</li>
-- `role="combobox"` - skipped in iOS as VoiceOver fails to inform current field is editable</li>
+
+- `aria-controls` - Reads 'tilgjengelig forslag' on windows Narrator on focus
 
 ### How do I use core-suggest with multiple tags/output values?
 Tagging and screen readers is a complex matter, requiring more than comma separated values. Currently, tagging is just a part of the wishlist for core-suggest. If tagging functionality is of interest for your project, please add a +1 to the [tagging task](https://github.com/nrkno/core-components/issues/9), describe your needs in a comment, and you'll be updated about progress.

--- a/packages/core-suggest/readme.md
+++ b/packages/core-suggest/readme.md
@@ -55,9 +55,9 @@ Modify the default notifications announced to screen readers when suggestions ar
 <label for="my-live-region-input">Search</label>
 <input id="my-live-region-input" type="text" placeholder="Type to filter">
 <core-suggest
-  live-region-shown-label="Suggestions are shown"
-  live-region-empty-label="No suggestions"
-  live-region-count-label="Showing {{value}} suggestions"
+  data-sr-shown-message="Suggestions are shown"
+  data-sr-empty-message="No suggestions"
+  data-sr-count-message="Showing {{value}} suggestions"
   hidden
 >
   <ul>
@@ -74,8 +74,8 @@ Modify the default notifications announced to screen readers when suggestions ar
 <label for="my-live-region-shown-input">Search</label>
 <input id="my-live-region-shown-input" type="text" placeholder="Type to filter">
 <core-suggest
-  live-region-shown-label="Suggestions are shown"
-  live-region-empty-label=""
+  data-sr-shown-message="Suggestions are shown"
+  data-sr-empty-message=""
   hidden
 >
   <ul>
@@ -92,8 +92,8 @@ Modify the default notifications announced to screen readers when suggestions ar
 <label for="my-live-region-filtered-input">Search</label>
 <input id="my-live-region-filtered-input" type="text" placeholder="Type to filter">
 <core-suggest
-  live-region-shown-label=""
-  live-region-empty-label="No suggestions"
+  data-sr-shown-message=""
+  data-sr-empty-message="No suggestions"
   hidden
 >
   <ul>
@@ -213,9 +213,9 @@ Synchronous operation; dynamically populate items based on input value:
     <label for="my-input-jsx">Search JSX</label>
     <input id='my-input-jsx' type='text' placeholder='Type something...' />
     <CoreSuggest
-      live-region-shown-label="Suggestions shown"
-      live-region-empty-label="No suggestions"
-      live-region-count-label="Showing {{value}} suggestions"
+      data-sr-shown-message="Suggestions shown"
+      data-sr-empty-message="No suggestions"
+      data-sr-count-message="Showing {{value}} suggestions"
       className='my-dropdown'
       hidden
     >
@@ -409,9 +409,9 @@ Core-suggest notifies screen readers using a polite aria-live region when sugges
 To do this, we append a `<span>` with `aria-live="polite"` and hide it from view. When something is notified, we set and subsequently clear the `textContent` of this span.
 
 Text sent to screen readers can be adjusted by setting the following attributes on the `core-suggest` element:
- * `live-region-shown-label="Forslag vises"`
- * `live-region-empty-label="Ingen forslag"`
- * `live-region-count-label="{{value}} forslag"`
+ * `data-sr-shown-message="Forslag vises"`
+ * `data-sr-empty-message="Ingen forslag"`
+ * `data-sr-count-message="{{value}} forslag"`
 
 **NB!** When updating contents of a `<core-suggest>` element, avoid replacing the `innerHTML` (and thus removing the aria-live region) of the suggest. By updating the contents of a child element, e.g a `<ul>`, the aria-live region is present and will be able to announce that suggestions are shown.
 
@@ -424,9 +424,9 @@ Text sent to screen readers can be adjusted by setting the following attributes 
 <core-suggest limit="{Number}"                          <!-- Optional. Limit maxium number of result items. Defaults to Infinity -->
               ajax="{String}"                           <!-- Optional. Fetches external data. See event 'suggest.ajax'. Example: 'https://search.com?q={{value}}' -->
               highlight="{'on' | 'off' | 'keep'}"       <!-- Optional override of highlighting matches in results. Defaults to 'on'. -->
-              live-region-shown-label                   <!-- Optional. Override text sent to aria-live region when suggestions are shown -->
-              live-region-empty-label                   <!-- Optional. Override text sent to aria-live region when suggestions are empty due to filter -->
-              live-region-count-label                   <!-- Optional. Override text sent to aria-live region when suggestions are counted as part of filtering -->
+              data-sr-shown-message                     <!-- Optional. Override text sent to aria-live region when suggestions are shown -->
+              data-sr-empty-message                     <!-- Optional. Override text sent to aria-live region when suggestions are empty due to filter -->
+              data-sr-count-message                     <!-- Optional. Override text sent to aria-live region when suggestions are counted as part of filtering -->
               hidden>                                   <!-- Use hidden to toggle visibility -->
   <ul>                                                  <!-- Can be any tag, but items should be inside <li> -->
     <li><button>Item 1</button></li>                    <!-- Items must be <button> or <a> -->

--- a/packages/core-suggest/readme.md
+++ b/packages/core-suggest/readme.md
@@ -25,7 +25,6 @@ demo-->
 > search results and smart select box abilities and automatic highlighting. Results can be with fetched directly from markup
 > or from a custom endpoint with AJAX.
 
-
 ## Examples (Plain JS)
 
 #### Static content
@@ -35,13 +34,17 @@ Use core-suggest to filter static markup
 ```html
 <!--demo-->
 <label for="my-input">Search</label>
-<input id="my-input" type="text" placeholder="Type something..." list="live-suggest">
-<core-suggest
-  id='live-suggest'
-  hidden
->
+<input
+  id="my-input"
+  type="text"
+  placeholder="Type something..."
+  list="live-suggest"
+/>
+<core-suggest id="live-suggest" hidden>
   <ul>
-    <li><button>Chro<b>me</b></button></li>
+    <li>
+      <button>Chro<b>me</b></button>
+    </li>
     <li><button>Firefox</button></li>
     <li><button>Opera</button></li>
     <li><button>Safari</button></li>
@@ -49,6 +52,7 @@ Use core-suggest to filter static markup
   </ul>
 </core-suggest>
 ```
+
 #### Live-region
 
 Modify the default notifications announced to screen readers when suggestions are visible, empty and filtered
@@ -58,9 +62,9 @@ Modify the default notifications announced to screen readers when suggestions ar
 
 <p>Custom label values</p>
 <label for="my-live-region-input">Search</label>
-<input id="my-live-region-input" type="text" placeholder="Type to filter">
+<input id="my-live-region-input" type="text" placeholder="Type to filter" />
 <core-suggest
-  data-sr-shown-message="Suggestions are shown"
+  data-sr-shown-message="{{value}} suggestions shown"
   data-sr-empty-message="No suggestions"
   data-sr-count-message="Showing {{value}} suggestions"
   hidden
@@ -77,10 +81,15 @@ Modify the default notifications announced to screen readers when suggestions ar
 <p>Only notify when suggestions are shown</p>
 
 <label for="my-live-region-shown-input">Search</label>
-<input id="my-live-region-shown-input" type="text" placeholder="Type to filter">
+<input
+  id="my-live-region-shown-input"
+  type="text"
+  placeholder="Type to filter"
+/>
 <core-suggest
   data-sr-shown-message="Suggestions are shown"
   data-sr-empty-message=""
+  data-sr-count-message=""
   hidden
 >
   <ul>
@@ -95,10 +104,15 @@ Modify the default notifications announced to screen readers when suggestions ar
 <p>Only notify when suggestions are removed by filter</p>
 
 <label for="my-live-region-filtered-input">Search</label>
-<input id="my-live-region-filtered-input" type="text" placeholder="Type to filter">
+<input
+  id="my-live-region-filtered-input"
+  type="text"
+  placeholder="Type to filter"
+/>
 <core-suggest
   data-sr-shown-message=""
   data-sr-empty-message="No suggestions"
+  data-sr-count-message=""
   hidden
 >
   <ul>
@@ -115,98 +129,140 @@ Modify the default notifications announced to screen readers when suggestions ar
 
 Ajax requests can be stopped by calling `event.preventDefault()` on `'suggest.filter'`. Remember to always escape html and debounce requests when fetching data from external sources. The http request sent by `@nrk/core-suggest` will have header `X-Requested-With: XMLHttpRequest` for easier [server side detection and CSRF prevention](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html).
 
-
 Note: When using `@nrk/core-suggest` with the `ajax: https://search.com?q={{value}}` functionality, make sure to implement both a `Searching...` status (while fetching data from the server), and a `No hits` status (if server responds with no results). These status indicators are highly recommended, but not provided by default as the context of use will affect the optimal textual formulation. [See example implementation →](#example-ajax)
 
-If you need to alter default headers, request method or post data, use the [`suggest.ajax.beforeSend` event  →](#input-ajax-beforesend)
+If you need to alter default headers, request method or post data, use the [`suggest.ajax.beforeSend` event →](#input-ajax-beforesend)
 
 ```html
 <!--demo-->
-<input id="my-input-ajax" placeholder="Country...">
-<core-suggest ajax="https://restcountries.com/v2/name/{{value}}?fields=name" hidden></core-suggest>
+<input id="my-input-ajax" placeholder="Country..." />
+<core-suggest
+  ajax="https://restcountries.com/v2/name/{{value}}?fields=name"
+  hidden
+></core-suggest>
 <script>
-  document.addEventListener('suggest.filter', (event) => {
-    const suggest = event.target
-    const input = suggest.input
-    const value = input.value.trim()
+  document.addEventListener("suggest.filter", (event) => {
+    const suggest = event.target;
+    const input = suggest.input;
+    const value = input.value.trim();
 
-    if (input.id !== 'my-input-ajax') return // Make sure we are on correct input
-    suggest.innerHTML = value ? `<ul><li><button>Searching for ${value}...</button></li></ul>` : ''
-  })
-  document.addEventListener('suggest.ajax', (event) => {
-    const suggest = event.target
-    const input = suggest.input
+    if (input.id !== "my-input-ajax") return; // Make sure we are on correct input
+    suggest.innerHTML = value
+      ? `<ul><li><button>Searching for ${value}...</button></li></ul>`
+      : "";
+  });
+  document.addEventListener("suggest.ajax", (event) => {
+    const suggest = event.target;
+    const input = suggest.input;
 
-    if (input.id !== 'my-input-ajax') return // Make sure we are on correct input
-    const items = event.detail.responseJSON
-    suggest.innerHTML = `<ul>${items.length ? items.slice(0, 10)
-      .map((item) => { return `<li><button>${suggest.escapeHTML(item.name)}</button></li>` }) // Generate list
-      .join('') : '<li><button>No results</button></li>'}</ul>`
-  })
-  document.addEventListener('suggest.ajax.error', (event) => {
-    const suggest = event.target
-    const input = suggest.input
+    if (input.id !== "my-input-ajax") return; // Make sure we are on correct input
+    const items = event.detail.responseJSON;
+    suggest.innerHTML = `<ul>${
+      items.length
+        ? items
+            .slice(0, 10)
+            .map((item) => {
+              return `<li><button>${suggest.escapeHTML(
+                item.name
+              )}</button></li>`;
+            }) // Generate list
+            .join("")
+        : "<li><button>No results</button></li>"
+    }</ul>`;
+  });
+  document.addEventListener("suggest.ajax.error", (event) => {
+    const suggest = event.target;
+    const input = suggest.input;
 
-    if (input.id !== 'my-input-ajax') return // Make sure we are on correct input
-    console.log(event)
-    const items = event.detail.responseJSON
-    suggest.innerHTML = '<ul><li><button>No results</button></li></ul>'
-  })
+    if (input.id !== "my-input-ajax") return; // Make sure we are on correct input
+    console.log(event);
+    const items = event.detail.responseJSON;
+    suggest.innerHTML = "<ul><li><button>No results</button></li></ul>";
+  });
 </script>
 ```
+
 #### Lazy
 
 Hybrid solution; lazy load items, use `core-suggest` to handle filtering:
+
 ```html
 <!--demo-->
-<input id="my-input-lazy" placeholder="Filter lazy-loaded content">
+<input id="my-input-lazy" placeholder="Filter lazy-loaded content" />
 <core-suggest hidden></core-suggest>
 <script>
   window.getCountries = (callback) => {
-    const xhr = new XMLHttpRequest()
-    const url = 'https://restcountries.com/v3.1/all?fields=name'
+    const xhr = new XMLHttpRequest();
+    const url = "https://restcountries.com/v3.1/all?fields=name";
 
-    xhr.onload = () => callback(JSON.parse(xhr.responseText))
-    xhr.open('GET', url, true)
-    xhr.send()
-  }
+    xhr.onload = () => callback(JSON.parse(xhr.responseText));
+    xhr.open("GET", url, true);
+    xhr.send();
+  };
 
-  document.addEventListener('focus', (event) => {
-    if (event.target.id !== 'my-input-lazy') return // Make sure we are on correct input
-    const input = event.target
-    const suggest = input.nextElementSibling
+  document.addEventListener(
+    "focus",
+    (event) => {
+      if (event.target.id !== "my-input-lazy") return; // Make sure we are on correct input
+      const input = event.target;
+      const suggest = input.nextElementSibling;
 
-    input.id = '' // Prevent double execution
-    window.getCountries((items) => {
-      suggest.innerHTML = `<ul>${items.map((item) =>
-        '<li><button>' + suggest.escapeHTML(item.name?.common) + '</button></li>'
-      ).join('')}</ul>`
-    })
-  }, true)
+      input.id = ""; // Prevent double execution
+      window.getCountries((items) => {
+        suggest.innerHTML = `<ul>${items
+          .map(
+            (item) =>
+              "<li><button>" +
+              suggest.escapeHTML(item.name?.common) +
+              "</button></li>"
+          )
+          .join("")}</ul>`;
+      });
+    },
+    true
+  );
 </script>
 ```
 
-
 #### Dynamic
+
 Synchronous operation; dynamically populate items based on input value:
 
 ```html
 <!--demo-->
-<input id="my-input-dynamic" placeholder="Type to generate suggestions">
+<input id="my-input-dynamic" placeholder="Type to generate suggestions" />
 <core-suggest hidden></core-suggest>
 <script>
-  document.addEventListener('suggest.filter', (event) => {
-    const suggest = event.target
-    const input = suggest.input
-    const value = input.value.trim()
-    const mails = ['facebook.com', 'gmail.com', 'hotmail.com', 'mac.com', 'mail.com', 'msn.com', 'live.com']
+  document.addEventListener("suggest.filter", (event) => {
+    const suggest = event.target;
+    const input = suggest.input;
+    const value = input.value.trim();
+    const mails = [
+      "facebook.com",
+      "gmail.com",
+      "hotmail.com",
+      "mac.com",
+      "mail.com",
+      "msn.com",
+      "live.com",
+    ];
 
-    if (input.id !== 'my-input-dynamic') return // Make sure we are on correct input
-    event.preventDefault()
-    suggest.innerHTML = `<ul>${value ? mails.map((mail) => {
-      return '<li><button type="button">' + value.replace(/(@.*|$)/, '@' + mail) + '</button></li>'
-    }).join('') : ''}</ul>`
-  })
+    if (input.id !== "my-input-dynamic") return; // Make sure we are on correct input
+    event.preventDefault();
+    suggest.innerHTML = `<ul>${
+      value
+        ? mails
+            .map((mail) => {
+              return (
+                '<li><button type="button">' +
+                value.replace(/(@.*|$)/, "@" + mail) +
+                "</button></li>"
+              );
+            })
+            .join("")
+        : ""
+    }</ul>`;
+  });
 </script>
 ```
 
@@ -236,13 +292,14 @@ Synchronous operation; dynamically populate items based on input value:
   </div>, document.getElementById('jsx-input'))
 </script>
 ```
+
 #### Ajax
 
 Ajax requests can be stopped by calling `event.preventDefault()` on `'suggest.filter'`. Remember to always escape html and debounce requests when fetching data from external sources. The http request sent by `@nrk/core-suggest` will have header `X-Requested-With: XMLHttpRequest` for easier [server side detection and CSRF prevention](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html).
 
 Note: When using `@nrk/core-suggest` with the `ajax: https://search.com?q={{value}}` functionality, make sure to implement both a `Searching...` status (while fetching data from the server), and a `No hits` status (if server responds with no results). These status indicators are highly recommended, but not provided by default as the context of use will affect the optimal textual formulation. [See example implementation →](#example-ajax)
 
-If you need to alter default headers, request method or post data, use the [`suggest.ajax.beforeSend` event  →](#input-ajax-beforesend)
+If you need to alter default headers, request method or post data, use the [`suggest.ajax.beforeSend` event →](#input-ajax-beforesend)
 
 ```html
 <!--demo-->
@@ -291,7 +348,7 @@ If you need to alter default headers, request method or post data, use the [`sug
 </script>
 ```
 
-#### Lazy 
+#### Lazy
 
 Hybrid solution; lazy load items, but let `core-suggest` still handle filtering:
 
@@ -327,7 +384,6 @@ Hybrid solution; lazy load items, but let `core-suggest` still handle filtering:
 </script>
 ```
 
-
 #### Dynamic
 
 Synchronous operation; dynamically populate items based on input value:
@@ -337,35 +393,52 @@ Synchronous operation; dynamically populate items based on input value:
 <div id="jsx-input-dynamic"></div>
 <script>
   class DynamicInput extends React.Component {
-    constructor (props) {
-      super(props)
-      this.onFilter = this.onFilter.bind(this)
-      this.mails = ['facebook.com', 'gmail.com', 'hotmail.com', 'mac.com', 'mail.com', 'msn.com', 'live.com']
-      this.state = {items: []}
+    constructor(props) {
+      super(props);
+      this.onFilter = this.onFilter.bind(this);
+      this.mails = [
+        "facebook.com",
+        "gmail.com",
+        "hotmail.com",
+        "mac.com",
+        "mail.com",
+        "msn.com",
+        "live.com",
+      ];
+      this.state = { items: [] };
     }
-    onFilter (event) {
-      const suggest = event.target
-      const value = suggest.input.value.trim()
-      const items = value ? this.mails.map((mail) => value.replace(/(@.*|$)/, `@${mail}`)) : []
+    onFilter(event) {
+      const suggest = event.target;
+      const value = suggest.input.value.trim();
+      const items = value
+        ? this.mails.map((mail) => value.replace(/(@.*|$)/, `@${mail}`))
+        : [];
 
-      event.preventDefault()
-      this.setState({value, items})
+      event.preventDefault();
+      this.setState({ value, items });
     }
-    render () {
-      return <div>
-        <input type='text' placeholder='Type to generate suggestions' />
-        <CoreSuggest onSuggestFilter={this.onFilter}>
-          <ul className='my-dropdown'>
-            {this.state.items.map((text) =>
-              <li key={text}><button>{text}</button></li>
-            )}
-          </ul>
-        </CoreSuggest>
-      </div>
+    render() {
+      return (
+        <div>
+          <input type="text" placeholder="Type to generate suggestions" />
+          <CoreSuggest onSuggestFilter={this.onFilter}>
+            <ul className="my-dropdown">
+              {this.state.items.map((text) => (
+                <li key={text}>
+                  <button>{text}</button>
+                </li>
+              ))}
+            </ul>
+          </CoreSuggest>
+        </div>
+      );
     }
   }
 
-  ReactDOM.render(<DynamicInput />, document.getElementById('jsx-input-dynamic'))
+  ReactDOM.render(
+    <DynamicInput />,
+    document.getElementById("jsx-input-dynamic")
+  );
 </script>
 ```
 
@@ -381,15 +454,15 @@ npm install @nrk/core-suggest  # Using NPM
 Using static registers the custom element with default name automatically:
 
 ```html
-<script src="https://static.nrk.no/core-components/major/9/core-suggest/core-suggest.min.js"></script>  <!-- Using static -->
+<script src="https://static.nrk.no/core-components/major/9/core-suggest/core-suggest.min.js"></script>
+<!-- Using static -->
 ```
 
 Remember to [polyfill](https://github.com/webcomponents/polyfills/tree/master/packages/custom-elements) custom elements if needed.
 
-
 ## Usage
 
-Typing into the input toggles the [hidden attribute](https://developer.mozilla.org/en/docs/Web/HTML/Global_attributes/hidden) on items of type `<button>` and `<a>`, based on matching [textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) inside `<core-suggest>`. Focusing the input unhides the following element. The default filtering behavior can easily be altered through the `'suggest.select'`, `'suggest.filter'`, `'suggest.ajax'` and  `'suggest.ajax.beforeSend'` [events](#events).
+Typing into the input toggles the [hidden attribute](https://developer.mozilla.org/en/docs/Web/HTML/Global_attributes/hidden) on items of type `<button>` and `<a>`, based on matching [textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) inside `<core-suggest>`. Focusing the input unhides the following element. The default filtering behavior can easily be altered through the `'suggest.select'`, `'suggest.filter'`, `'suggest.ajax'` and `'suggest.ajax.beforeSend'` [events](#events).
 
 ### Security
 
@@ -402,11 +475,11 @@ The `highlight`-attribute accepts `'on', 'off', 'keep'`, defaults to `'on'`.
 Optional attribute to override how core-suggest handles `<mark>`-tags in results.
 Highlighting is disabled for IE11 due to errant behavior.
 
-VALUE | BEHAVIOUR
-:-- | :--
-`'on'` (default) | Strips existing `<mark>`-tags and wraps new matches in `<mark>`-tags
-`'off'` | Strips existing `<mark>`-tags, but does not wrap matches
-`'keep'` | Does not noting with `<mark>`-tags - existing tags are not stripped and no new matches are added
+| VALUE            | BEHAVIOUR                                                                                        |
+| :--------------- | :----------------------------------------------------------------------------------------------- |
+| `'on'` (default) | Strips existing `<mark>`-tags and wraps new matches in `<mark>`-tags                             |
+| `'off'`          | Strips existing `<mark>`-tags, but does not wrap matches                                         |
+| `'keep'`         | Does not noting with `<mark>`-tags - existing tags are not stripped and no new matches are added |
 
 ### Aria-live
 
@@ -415,53 +488,57 @@ Core-suggest notifies screen readers using a polite aria-live region when sugges
 To do this, we append a `<span>` with `aria-live="polite"` and hide it from view. When something is notified, we set and subsequently clear the `textContent` of this span.
 
 Text sent to screen readers can be adjusted by setting the following attributes on the `core-suggest` element:
- * `data-sr-shown-message="Forslag vises"`
- * `data-sr-empty-message="Ingen forslag"`
- * `data-sr-count-message="{{value}} forslag"`
+
+- `data-sr-shown-message="Forslag vises"`
+- `data-sr-empty-message="Ingen forslag"`
+- `data-sr-count-message="{{value}} forslag"`
 
 **NB!** When updating contents of a `<core-suggest>` element, avoid replacing the `innerHTML` (and thus removing the aria-live region) of the suggest. By updating the contents of a child element, e.g a `<ul>`, the aria-live region is present and will be able to announce that suggestions are shown.
 
 ### HTML / JavaScript
 
-
-```html
-<input type="text"                                      <!-- Must be a textual input element -->
-       list="{String}">                                 <!-- Optional. Specify id of suggest element -->
-<core-suggest limit="{Number}"                          <!-- Optional. Limit maxium number of result items. Defaults to Infinity -->
-              ajax="{String}"                           <!-- Optional. Fetches external data. See event 'suggest.ajax'. Example: 'https://search.com?q={{value}}' -->
-              highlight="{'on' | 'off' | 'keep'}"       <!-- Optional override of highlighting matches in results. Defaults to 'on'. -->
-              data-sr-shown-message                     <!-- Optional. Override text sent to aria-live region when suggestions are shown -->
-              data-sr-empty-message                     <!-- Optional. Override text sent to aria-live region when suggestions are empty due to filter -->
-              data-sr-count-message                     <!-- Optional. Override text sent to aria-live region when suggestions are counted as part of filtering -->
-              hidden>                                   <!-- Use hidden to toggle visibility -->
-  <ul>                                                  <!-- Can be any tag, but items should be inside <li> -->
-    <li><button>Item 1</button></li>                    <!-- Items must be <button> or <a> -->
-    <li><button value="Suprise!">Item 2</button></li>   <!-- Alternative value can be defined -->
-    <li><a href="https://www.nrk.no/">NRK.no</a></li>   <!-- Actual links are recommended when applicable -->
+```jsx
+<input
+ type="text" <!-- Must be a textual input element -->
+ list="{String}" <!-- Optional. Specify id of suggest element -->
+/>
+<core-suggest
+  limit="{Number}" <!-- Optional. Limit maxium number of result items. Defaults to Infinity -->
+  ajax="{String}" <!-- Optional. Fetches external data. See event 'suggest.ajax'. Example: 'https://search.com?q={{value}}' -->
+  highlight="{'on' | 'off' | 'keep'}" <!-- Optional. Override highlighting matches in results. Defaults to 'on'. -->
+  data-sr-shown-message="Forslag vises" <!-- Optional. Override text sent to aria-live region when suggestions are shown -->
+  data-sr-empty-message="Ingen forslag" <!-- Optional. Override text sent to aria-live region when suggestions are empty due to filter -->
+  data-sr-count-message="{{value}} forslag" <!-- Optional. Override text sent to aria-live region when suggestions are counted as part of filtering -->
+  hidden <!-- Use hidden to toggle visibility -->
+>
+  <ul>  <!-- Can be any tag, but items should be inside <li> -->
+    <li><button>Item 1</button></li>  <!-- Items must be <button> or <a> -->
+    <li><button value="Suprise!">Item 2</button></li> <!-- Alternative value can be defined -->
+    <li><a href="https://www.nrk.no/">NRK.no</a></li> <!-- Actual links are recommended when applicable -->
   </ul>
 </core-suggest>
 ```
 
 ```js
-import CoreSuggest from '@nrk/core-suggest'                 // Using NPM
-window.customElements.define('core-suggest', CoreSuggest)   // Using NPM. Replace 'core-suggest' with 'my-suggest' to namespace
+import CoreSuggest from "@nrk/core-suggest"; // Using NPM
+window.customElements.define("core-suggest", CoreSuggest); // Using NPM. Replace 'core-suggest' with e.g 'my-suggest' to namespace
 
-const mySuggest = document.querySelector('core-suggest')
+const mySuggest = document.querySelector("core-suggest");
 
 // Getters
-mySuggest.ajax       // Get ajax URL value
-mySuggest.limit      // Get limit
-mySuggest.highlight  // Get highlight
-mySuggest.hidden     // Get hidden
-mySuggest.input      // Get input for suggest
+mySuggest.ajax; // Get ajax URL value
+mySuggest.limit; // Get limit
+mySuggest.highlight; // Get highlight
+mySuggest.hidden; // Get hidden
+mySuggest.input; // Get input for suggest
 // Setters
-mySuggest.ajax = "https://search.com?q={{value}}"    // Set ajax endpoint URL for fetching external data.
-mySuggest.limit = 5                                  // Set limit for results
-mySuggest.highlight = 'on' | 'off' | 'keep'          // Set highlight strategy
-mySuggest.hidden = false                             // Set hidden value
+mySuggest.ajax = "https://search.com?q={{value}}"; // Set ajax endpoint URL for fetching external data.
+mySuggest.limit = 5; // Set limit for results
+mySuggest.highlight = "on" | "off" | "keep"; // Set highlight strategy
+mySuggest.hidden = false; // Set hidden value
 // Methods
-mySuggest.escapeHTML('<span>...</span>')             // Utility function for escaping HTML string
-mySuggest.pushToLiveRegion('Message to be read')     // Sends string content to aria-live region to notify screen readers
+mySuggest.escapeHTML("<span>...</span>"); // Utility function for escaping HTML string
+mySuggest.pushToLiveRegion("Message to be read"); // Sends string content to aria-live region to notify screen readers
 ```
 
 ### React / Preact
@@ -498,113 +575,117 @@ Putting the input directly before the suggestion list is highly recommended, as 
 
 ```html
 <label>
-  <input list="my-list" type="text" placeholder="...">
+  <input list="my-list" type="text" placeholder="..." />
 </label>
-<core-suggest id="my-list" hidden>
-  ...
-</core-suggest>
+<core-suggest id="my-list" hidden> ... </core-suggest>
 ```
-
 
 ## Events
 
 ### suggest.filter
+
 Fired before a default filtering occurs. If you wish to handle filtering yourself, e.g fuzzy search or similar, use `event.preventDefault()` to disable the default filtering.
 
 ```js
-document.addEventListener('suggest.filter', (event) => {
-  event.target      // The core-suggest element
-})
+document.addEventListener("suggest.filter", (event) => {
+  event.target; // The core-suggest element
+});
 ```
 
 ### suggest.select
+
 Fired when an item is clicked/selected:
 
 ```js
-document.addEventListener('suggest.select', (event) => {
-  event.target        // The core-suggest element
-  event.target.value  // The selected data
-  event.detail        // The selected element
-})
+document.addEventListener("suggest.select", (event) => {
+  event.target; // The core-suggest element
+  event.target.value; // The selected data
+  event.detail; // The selected element
+});
 ```
 
 ### suggest.ajax.beforeSend
+
 Fired before sending debounced ajax requests. If you wish to alter the [XMLHttpRequest](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest), use `event.preventDefault()` and then execute [XHR methods](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#Methods) on the `event.detail`. If not prevented, requests are sent using the `GET` method and the header `'X-Requested-With': 'XMLHttpRequest'`.
 
 ```js
-document.addEventListener('suggest.ajax.beforeSend', (event) => {
-  event.target  // The core-suggest element
-  event.detail  // The XMLHttpRequest object
-})
+document.addEventListener("suggest.ajax.beforeSend", (event) => {
+  event.target; // The core-suggest element
+  event.detail; // The XMLHttpRequest object
+});
 ```
 
 ```js
 // Example
-document.addEventListener('suggest.ajax.beforeSend', (event) => {
-  const xhr = event.detail
-  event.preventDefault() // Stop default behaviour
-  xhr.open('POST', 'https://example.com')
-  xhr.setRequestHeader('Content-Type', 'application/json')
-  xhr.setRequestHeader('my-custom-header', 'my-custom-value')
-  xhr.send(JSON.stringify({query: event.target.input.value}))
-})
+document.addEventListener("suggest.ajax.beforeSend", (event) => {
+  const xhr = event.detail;
+  event.preventDefault(); // Stop default behaviour
+  xhr.open("POST", "https://example.com");
+  xhr.setRequestHeader("Content-Type", "application/json");
+  xhr.setRequestHeader("my-custom-header", "my-custom-value");
+  xhr.send(JSON.stringify({ query: event.target.input.value }));
+});
 ```
 
 ### suggest.ajax
+
 Fired when the input field receives data from ajax:
 
 ```js
-document.addEventListener('suggest.ajax', (event) => {
-  event.target  // The core-suggest element
-  event.detail  // The XMLHttpRequest object
-  event.detail.responseText  // The response body text
-  event.detail.responseJSON  // The response json. Defaults to false if no valid JSON found
-})
+document.addEventListener("suggest.ajax", (event) => {
+  event.target; // The core-suggest element
+  event.detail; // The XMLHttpRequest object
+  event.detail.responseText; // The response body text
+  event.detail.responseJSON; // The response json. Defaults to false if no valid JSON found
+});
 ```
 
 ### suggest.ajax.error
+
 Fired when the request fails either due to a bad request (bad URL, non-200 response), an network error or a JSON parse error. Inspect `xhr.status` and `xhr.statusText` for bad requests and `xhr.responseError` for other errors:
 
 ```js
-document.addEventListener('suggest.ajax.error', (event) => {
-  event.target  // The core-suggest element
-  event.detail  // The XMLHttpRequest object
-  event.detail.status         // The response status code
-  event.detail.statusText     // The response status text
-  event.detail.responseError  // The error message for ajax errors/json parse errors
-})
+document.addEventListener("suggest.ajax.error", (event) => {
+  event.target; // The core-suggest element
+  event.detail; // The XMLHttpRequest object
+  event.detail.status; // The response status code
+  event.detail.statusText; // The response status text
+  event.detail.responseError; // The error message for ajax errors/json parse errors
+});
 ```
 
 ```js
 // Example
-document.addEventListener('suggest.ajax.error', (event) => {
-  const xhr = event.detail
+document.addEventListener("suggest.ajax.error", (event) => {
+  const xhr = event.detail;
   if (xhr.status !== 200) {
-    if (xhr.responseError) {             // Network error / JSON parse error
-      console.log(xhr.responseError)     // Log error message
-    } else {                             // Bad request
-      console.log(xhr.statusText)        // Log status text
-      console.log(xhr.responseText)      // Log response text
+    if (xhr.responseError) {
+      // Network error / JSON parse error
+      console.log(xhr.responseError); // Log error message
+    } else {
+      // Bad request
+      console.log(xhr.statusText); // Log status text
+      console.log(xhr.responseText); // Log response text
     }
   }
-})
+});
 ```
 
-
 ## Styling
+
 All styling in documentation is example only. Both the `<button>` and content element receive attributes reflecting the current toggle state:
 
 ```css
-.my-input {}                          /* Target input in any state */
-.my-input[aria-expanded="true"] {}    /* Target only open button */
-.my-input[aria-expanded="false"] {}   /* Target only closed button */
+.my-input {} // Target input in any state
+.my-input[aria-expanded="true"] {} // Target only open button
+.my-input[aria-expanded="false"] {} // Target only closed button
 
-.my-input-content {}                  /* Target content element in any state */
-.my-input-content:not([hidden]) {}    /* Target only open content */
-.my-input-content[hidden] {}          /* Target only closed content */
+.my-input-content {} // Target content element in any state
+.my-input-content:not([hidden]) {} // Target only open content
+.my-input-content[hidden] {} // Target only closed content
 
-.my-input-content :focus {}           /* Target focused item */
-.my-input-content mark {}             /* Target highlighted text (use `highlight='off'` to disable highlighting) */
+.my-input-content :focus {} // Target focused item
+.my-input-content mark {} // Target highlighted text (use `highlight='off'` to disable highlighting)
 ```
 
 ## Notes on accessibility
@@ -612,9 +693,10 @@ All styling in documentation is example only. Both the `<button>` and content el
 ### Screen reader notifications
 
 Release 1.3.0 introduced screen reader notifications for the following scenarios:
- - Suggestions become visible to the user, message defaults to `Forslag vises`.
- - The number of suggestions are announced when it changes, message defaults to `{{value}} forslag`.
- - When no suggestions remain, message defaults to `Ingen forslag`.
+
+- Suggestions become visible to the user, message defaults to `Forslag vises`.
+- The number of suggestions are announced when it changes, message defaults to `{{value}} forslag`.
+- When no suggestions remain, message defaults to `Ingen forslag`.
 
 Norwegian language is used by default, but the content can be changed by setting the appropriate [attributes](#aria-live)
 
@@ -622,12 +704,11 @@ These notifications have been added to improve the user experience when using sc
 
 As part of verifying compatibility with various screen-readers we made the following observations:
 
-* When using NVDA, JAWS or Narrator on Windows, notification when visible (`Forslag vises`) is superfluous as `aria-expanded` conveyes that the content is expanded. It is kept in for broader support across platforms.
-* 
+- When using NVDA, JAWS or Narrator on Windows, notification when visible (`Forslag vises`) is superfluous as `aria-expanded` conveyes that the content is expanded. It is kept in for broader support across platforms.
 
-Using JAWS version 2022-04 on windows 10, NVDA version 2021.3.5 on windows 10, Narrator on windows 10, TalkBack on EMUI 100
-Testing resuls as of `2022-05-10`:
+Using JAWS version 2022-04 on windows 10, NVDA version 2021.3.5 on windows 10, Narrator on windows 10, TalkBack on EMUI 12.
 
+Testing results as of `2022-05-10`:
 
 <div class="table-wrapper" tabindex="0">
 <table>
@@ -806,9 +887,11 @@ Testing resuls as of `2022-05-10`:
 ## FAQ
 
 ### Why not use `<datalist>` instead?
+
 Despite having a native [`<datalist>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist) element for autocomplete lists, there are several issues regarding [browser support](https://caniuse.com/#feat=details), varying [accessibility](http://accessibleculture.org/articles/2012/03/screen-readers-and-details-summary/) support as well as no ability for custom styling or custom behavior.
 
 ### Why is there only a subset of aria attributes in use?
+
 Despite well documented [examples in the aria 1.1 spesification](https://www.w3.org/TR/2017/NOTE-wai-aria-practices-1.1-20171214/examples/combobox/aria1.1pattern/listbox-combo.html), "best practice" simply becomes unusable in several screen reader due to implementation differences. `core-suggest` aims to provide a equally good user experience regardless if a screen reader passes events to browser or not (events are often hijacked for quick-navigation). Several techniques and attributes have been thoroughly tested:
 
 - `aria-activedescendant`/`aria-selected` - ignored in Android, lacks indication of list length in JAWS</li>
@@ -820,4 +903,5 @@ Despite well documented [examples in the aria 1.1 spesification](https://www.w3.
 - `aria-controls` - Reads 'tilgjengelig forslag' on windows Narrator on focus
 
 ### How do I use core-suggest with multiple tags/output values?
+
 Tagging and screen readers is a complex matter, requiring more than comma separated values. Currently, tagging is just a part of the wishlist for core-suggest. If tagging functionality is of interest for your project, please add a +1 to the [tagging task](https://github.com/nrkno/core-components/issues/9), describe your needs in a comment, and you'll be updated about progress.

--- a/packages/core-suggest/readme.md
+++ b/packages/core-suggest/readme.md
@@ -2,7 +2,7 @@
 
 <!-- <script src="https://unpkg.com/preact"></script>
 <script src="https://unpkg.com/preact-compat"></script>
-<script>
+<script type="text/javascript">
   window.React = preactCompat
   window.ReactDOM = preactCompat
 </script> -->
@@ -196,7 +196,7 @@ Hybrid solution; lazy load items, use `core-suggest` to handle filtering:
 <!--demo-->
 <input id="my-input-lazy" placeholder="Filter lazy-loaded content" />
 <core-suggest hidden></core-suggest>
-<script>
+<script type="text/javascript">
   window.getCountries = (callback) => {
     const xhr = new XMLHttpRequest();
     const url = "https://restcountries.com/v3.1/all?fields=name";
@@ -238,7 +238,7 @@ Synchronous operation; dynamically populate items based on input value:
 <!--demo-->
 <input id="my-input-dynamic" placeholder="Type to generate suggestions" />
 <core-suggest hidden></core-suggest>
-<script>
+<script type="text/javascript">
   document.addEventListener("suggest.filter", (event) => {
     const suggest = event.target;
     const input = suggest.input;
@@ -279,7 +279,7 @@ Synchronous operation; dynamically populate items based on input value:
 ```html
 <!--demo-->
 <div id="jsx-input"></div>
-<script type="text/jsx">
+<script type="text/javascript">
   ReactDOM.render(<div>
     <label for="my-input-jsx">Search JSX</label>
     <input id='my-input-jsx' type='text' placeholder='Type something...' />
@@ -366,7 +366,7 @@ Hybrid solution; lazy load items, but let `core-suggest` still handle filtering:
 ```html
 <!--demo-->
 <div id="jsx-input-lazy"></div>
-<script type="text/jsx">
+<script type="text/javascript">
   class LazyInput extends React.Component {
     constructor (props) {
       super(props)
@@ -402,7 +402,7 @@ Synchronous operation; dynamically populate items based on input value:
 ```html
 <!--demo-->
 <div id="jsx-input-dynamic"></div>
-<script>
+<script type="text/javascript">
   class DynamicInput extends React.Component {
     constructor(props) {
       super(props);

--- a/packages/core-suggest/readme.md
+++ b/packages/core-suggest/readme.md
@@ -38,9 +38,8 @@ Use core-suggest to filter static markup
   id="my-input"
   type="text"
   placeholder="Type something..."
-  list="live-suggest"
 />
-<core-suggest id="live-suggest" hidden>
+<core-suggest hidden>
   <ul>
     <li>
       <button>Chro<b>me</b></button>
@@ -53,66 +52,16 @@ Use core-suggest to filter static markup
 </core-suggest>
 ```
 
-#### Live-region
-
-Modify the default notifications announced to screen readers when suggestions are visible, empty and filtered
+You can modify the default notifications announced to screen readers when suggestions are visible, empty and filtered using the `data-sr`-attributes
 
 ```html
 <!--demo-->
 
-<p>Custom label values</p>
-<label for="my-live-region-input">Search</label>
+<label for="my-live-region-input">Search with english screen reader-messages</label>
 <input id="my-live-region-input" type="text" placeholder="Type to filter" />
 <core-suggest
-  data-sr-shown-message="{{value}} suggestions shown"
-  data-sr-empty-message="No suggestions"
-  data-sr-count-message="Showing {{value}} suggestions"
-  hidden
->
-  <ul>
-    <li><button>Chrome</button></li>
-    <li><button>Firefox</button></li>
-    <li><button>Opera</button></li>
-    <li><button>Safari</button></li>
-    <li><button>Microsoft Edge</button></li>
-  </ul>
-</core-suggest>
-
-<p>Only notify when suggestions are shown</p>
-
-<label for="my-live-region-shown-input">Search</label>
-<input
-  id="my-live-region-shown-input"
-  type="text"
-  placeholder="Type to filter"
-/>
-<core-suggest
-  data-sr-shown-message="Suggestions are shown"
-  data-sr-empty-message=""
-  data-sr-count-message=""
-  hidden
->
-  <ul>
-    <li><button>Chrome</button></li>
-    <li><button>Firefox</button></li>
-    <li><button>Opera</button></li>
-    <li><button>Safari</button></li>
-    <li><button>Microsoft Edge</button></li>
-  </ul>
-</core-suggest>
-
-<p>Only notify when suggestions are removed by filter</p>
-
-<label for="my-live-region-filtered-input">Search</label>
-<input
-  id="my-live-region-filtered-input"
-  type="text"
-  placeholder="Type to filter"
-/>
-<core-suggest
-  data-sr-shown-message=""
-  data-sr-empty-message="No suggestions"
-  data-sr-count-message=""
+  data-sr-empty-message="No suggestions shown"
+  data-sr-count-message="{{value}} suggestions shown"
   hidden
 >
   <ul>
@@ -139,6 +88,7 @@ Note: These status indicators are highly recommended, but are not provided by de
 
 ```html
 <!--demo-->
+<label for="my-input-ajax">Search with remotesuggestions</label>
 <input id="my-input-ajax" placeholder="Country..." />
 <core-suggest
   ajax="https://restcountries.com/v2/name/{{value}}?fields=name"
@@ -194,6 +144,7 @@ Hybrid solution; lazy load items, use `core-suggest` to handle filtering:
 
 ```html
 <!--demo-->
+<label for="my-input-lazy">Search with lazy suggestions</label>
 <input id="my-input-lazy" placeholder="Filter lazy-loaded content" />
 <core-suggest hidden></core-suggest>
 <script type="text/javascript">
@@ -236,6 +187,7 @@ Synchronous operation; dynamically populate items based on input value:
 
 ```html
 <!--demo-->
+<label for="my-input-dynamic">Search with generated suggestions</label>
 <input id="my-input-dynamic" placeholder="Type to generate suggestions" />
 <core-suggest hidden></core-suggest>
 <script type="text/javascript">
@@ -281,7 +233,7 @@ Synchronous operation; dynamically populate items based on input value:
 <div id="jsx-input"></div>
 <script type="text/javascript">
   ReactDOM.render(<div>
-    <label for="my-input-jsx">Search JSX</label>
+    <label for="my-input-jsx">Search med lang label</label>
     <input id='my-input-jsx' type='text' placeholder='Type something...' />
     <CoreSuggest
       className='my-dropdown'
@@ -496,15 +448,13 @@ Highlighting is disabled for IE11 due to errant behavior.
 
 Core-suggest notifies screen readers using a polite aria-live region when suggestions are shown and status of filter changes; number of suggestions and when there are no suggestions, by default.
 
-To do this, we append a `<span>` with `aria-live="polite"` and hide it from view. When something is notified, we set and subsequently clear the `textContent` of this span.
+To do this, we append a `<span>` with `aria-live="polite"` to the document body and hide it from view. When something is notified, we set and subsequently clear the `textContent` of this span.
 
 Text sent to screen readers can be adjusted by setting the following attributes on the `core-suggest` element:
 
-- `data-sr-shown-message="Forslag vises"`
-- `data-sr-empty-message="Ingen forslag"`
-- `data-sr-count-message="{{value}} forslag"`
-
-**NB!** When updating contents of a `<core-suggest>` element, avoid replacing the `innerHTML` (and thus removing the aria-live region) of the suggest. By updating the contents of a child element, e.g a `<ul>`, the aria-live region is present and will be able to announce that suggestions are shown.
+- `data-sr-empty-message="Ingen forslag vises"`
+- `data-sr-count-message="{{value}} forslag vises"`
+- `data-sr-read-text-content`
 
 ### HTML / JavaScript
 
@@ -517,9 +467,9 @@ Text sent to screen readers can be adjusted by setting the following attributes 
   limit="{Number}" <!-- Optional. Limit maxium number of result items. Defaults to Infinity -->
   ajax="{String}" <!-- Optional. Fetches external data. See event 'suggest.ajax'. Example: 'https://search.com?q={{value}}' -->
   highlight="{'on' | 'off' | 'keep'}" <!-- Optional. Override highlighting matches in results. Defaults to 'on'. -->
-  data-sr-shown-message="Forslag vises" <!-- Optional. Override text sent to aria-live region when suggestions are shown -->
-  data-sr-empty-message="Ingen forslag" <!-- Optional. Override text sent to aria-live region when suggestions are empty due to filter -->
-  data-sr-count-message="{{value}} forslag" <!-- Optional. Override text sent to aria-live region when suggestions are counted as part of filtering -->
+  data-sr-empty-message="Ingen forslag vises" <!-- Optional. Override text sent to aria-live region when suggestions are empty due to filter -->
+  data-sr-count-message="{{value}} forslag vises" <!-- Optional. Override text sent to aria-live region when (the number of) suggestions changes -->
+  data-sr-read-text-content <!-- Optional. When present, `textContent` will be sent to screen reader when no buttons or links are present -->
   hidden <!-- Use hidden to toggle visibility -->
 >
   <ul>  <!-- Can be any tag, but items should be inside <li> -->
@@ -580,16 +530,8 @@ import CoreSuggest from '@nrk/core-suggest/jsx'
 
 ## Markup
 
-### With list
+Putting the input directly before the suggestion list is highly recommended, as this fulfills all accessibility requirements by default. There may be scenarios, where styling makes this DOM structure impractical. In such cases, give the `<input>` a `list` attribute, and the `<core-suggest>` an `id` with corresponding value. Make sure there is no text between the input and the suggestion list, as this will break the experience for screen reader users.
 
-Putting the input directly before the suggestion list is highly recommended, as this fulfills all accessibility requirements by default. There might be scenarios though, where styling makes this DOM structure impractical. In such cases, give the `<input>` a `list` attribute, and the `<core-suggest>` an `id` with corresponding value. Make sure there is no text between the input and the suggestion list, as this will break the experience for screen reader users:
-
-```html
-<label>
-  <input list="my-list" type="text" placeholder="..." />
-</label>
-<core-suggest id="my-list" hidden> ... </core-suggest>
-```
 
 ## Events
 
@@ -705,9 +647,10 @@ All styling in documentation is example only. Both the `<button>` and content el
 
 Release 1.3.0 introduced screen reader notifications for the following scenarios:
 
-- Suggestions become visible to the user, message defaults to `Forslag vises`.
-- The number of suggestions are announced when it changes, message defaults to `{{value}} forslag`.
-- When no suggestions remain, message defaults to `Ingen forslag`.
+- Suggestions become visible to the user, e.g. input is focused or selected input receives lazy-loaded items. Message defaults to `{{value}} Forslag vises`.
+- The number of suggestions are announced when it changes, e.g. when filtering or async update. Message defaults to `{{value}} forslag vises`.
+- When no suggestions remain due to filtering. Message defaults to `Ingen forslag vises`.
+- `textContent` is displayed, e.g. load/error state in [ajax example](#examples-plain-js--ajax). `textContent` within core-suggest element is trimmed and sent to screen reader when `data-sr-read-text-content`-attribute is present
 
 Norwegian language is used by default, but the content can be changed by setting the appropriate [attributes](#aria-live)
 
@@ -715,110 +658,100 @@ These notifications have been added to improve the user experience when using sc
 
 As part of verifying compatibility with various screen-readers we made the following observations:
 
-- When using NVDA, JAWS or Narrator on Windows, notification when visible (`Forslag vises`) is superfluous as `aria-expanded` conveyes that the content is expanded. It is kept in for broader support across platforms.
+- We found it necessary to apply a delay when sending messages to the screen reader. Without it, messages sometimes failed to register properly or were ignored completely where the length of label was more than one word.
+- When using NVDA, JAWS or Narrator on Windows, notification when visible (`n Forslag vises`) is superfluous as `aria-expanded` conveyes that the content is expanded. It is kept in for broader support across platforms.
 
-Using JAWS version 2022-04 on windows 10, NVDA version 2021.3.5 on windows 10, Narrator on windows 10, TalkBack on EMUI 12.
-
-Testing results as of `2022-05-10`:
-
-<div class="table-wrapper" tabindex="0">
-<table>
-  <caption>Screen reader is notified when suggestions become visible to the user</caption>
-  <colgroup span="3"></colgroup>
-  <colgroup span="2"></colgroup>
-  <colgroup span="3"></colgroup>
-  <colgroup span="1"></colgroup>
-  <colgroup span="1"></colgroup>
-  <colgroup span="2"></colgroup>
-  <colgroup span="2"></colgroup>
-  <tbody>
-    <tr>
-      <th colspan="3" scope="colgroup">JAWS</th>
-      <th colspan="2" scope="colgroup">Narrator</th>
-      <th colspan="3" scope="colgroup">NVDA</th>
-      <th colspan="1" scope="colgroup">Orca</th>
-      <th colspan="1" scope="colgroup">TalkBack</th>
-      <th colspan="2" scope="colgroup">VoiceOver (iOS)</th>
-      <th colspan="2" scope="colgroup">VoiceOver (macOS)</th>
-    </tr>
-    <tr>
-      <th scope="col">Chrome</th>
-      <th scope="col">Edge</th>
-      <th scope="col">Firefox</th>
-      <th scope="col">Chrome</th>
-      <th scope="col">Edge</th>
-      <th scope="col">Chrome</th>
-      <th scope="col">Edge</th>
-      <th scope="col">Firefox</th>
-      <th scope="col">Firefox</th>
-      <th scope="col">Chrome</th>
-      <th scope="col">Safari</th>
-      <th scope="col">Chrome</th>
-      <th scope="col">Safari</th>
-      <th scope="col">Chrome</th>
-    </tr>
-    <tr>
-      <td>Supported</td>
-      <td>Supported</td>
-      <td>Partial *</td>
-      <td>Supported</td>
-      <td>Supported</td>
-      <td>Supported</td>
-      <td>Supported</td>
-      <td>Supported</td>
-      <td>Partial *</td>
-      <td>Supported</td>
-      <td>Supported</td>
-      <td>Supported</td>
-      <td>Supported</td>
-      <td>Supported</td>
-    </tr>
-  </tbody>
-</table>
-</div>
-
-`*` JAWS and Orca on Firefox will not always relay visible suggestions, but is covered by `aria-expanded`.
+Using JAWS version 2022-04 on windows 10, NVDA version 2021.3.5 on windows 10, Narrator on windows 10, Orca 3.36.2, TalkBack on EMUI 12 and Android 9, VoiceOver on iOS 15.4.1 and macOS Big Sur and Monterey.
 
 <div class="table-wrapper" tabindex="0">
 <table>
-  <caption>Screen reader is notified when the number of suggestions changes</caption>
+  <caption>Screen reader testing results as of <date>2022-05-25</date></caption>
+  <colgroup span="1"></colgroup>
   <colgroup span="3"></colgroup>
-  <colgroup span="2"></colgroup>
+  <colgroup span="3"></colgroup>
   <colgroup span="3"></colgroup>
   <colgroup span="1"></colgroup>
-  <colgroup span="1"></colgroup>
   <colgroup span="2"></colgroup>
   <colgroup span="2"></colgroup>
+  <colgroup span="2"></colgroup>
+  <thead>
+    <tr>
+      <th colspan="1" scope="colgroup">Situation</th>
+      <th colspan="3" scope="colgroup"><a href="https://www.freedomscientific.com/products/software/jaws/">JAWS</a></th>
+      <th colspan="3" scope="colgroup"><a href="https://support.microsoft.com/en-us/windows/complete-guide-to-narrator-e4397a0d-ef4f-b386-d8ae-c172f109bdb1">Narrator</a></th>
+      <th colspan="3" scope="colgroup"><a href="https://www.nvaccess.org/">NVDA</a></th>
+      <th colspan="1" scope="colgroup"><a href="https://help.gnome.org/users/orca/stable/">Orca</a></th>
+      <th colspan="2" scope="colgroup"><a href="https://support.google.com/accessibility/android/answer/6283677?hl=en">TalkBack</a></th>
+      <th colspan="2" scope="colgroup"><a href="https://support.apple.com/en-gb/guide/iphone/iph3e2e415f/ios">VoiceOver (iOS)</a></th>
+      <th colspan="2" scope="colgroup"><a href="https://support.apple.com/en-gb/guide/voiceover/welcome/mac">VoiceOver (macOS)</a></th>
+    </tr>
+    <tr>
+      <th scope="col"></th>
+      <th scope="col">Chrome</th>
+      <th scope="col">Edge</th>
+      <th scope="col">Firefox</th>
+      <th scope="col">Chrome</th>
+      <th scope="col">Edge</th>
+      <th scope="col">Firefox</th>
+      <th scope="col">Chrome</th>
+      <th scope="col">Edge</th>
+      <th scope="col">Firefox</th>
+      <th scope="col">Firefox</th>
+      <th scope="col">Chrome</th>
+      <th scope="col">Samsung Internet</th>
+      <th scope="col">Safari</th>
+      <th scope="col">Chrome</th>
+      <th scope="col">Safari</th>
+      <th scope="col">Chrome</th>
+    </tr>
+  </thead>
   <tbody>
     <tr>
-      <th colspan="3" scope="colgroup">JAWS</th>
-      <th colspan="2" scope="colgroup">Narrator</th>
-      <th colspan="3" scope="colgroup">NVDA</th>
-      <th colspan="1" scope="colgroup">Orca</th>
-      <th colspan="1" scope="colgroup">TalkBack</th>
-      <th colspan="2" scope="colgroup">VoiceOver (iOS)</th>
-      <th colspan="2" scope="colgroup">VoiceOver (macOS)</th>
+      <th>Suggestions visible on focus or lazy load</th>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Not supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
     </tr>
     <tr>
-      <th scope="col">Chrome</th>
-      <th scope="col">Edge</th>
-      <th scope="col">Firefox</th>
-      <th scope="col">Chrome</th>
-      <th scope="col">Edge</th>
-      <th scope="col">Chrome</th>
-      <th scope="col">Edge</th>
-      <th scope="col">Firefox</th>
-      <th scope="col">Firefox</th>
-      <th scope="col">Chrome</th>
-      <th scope="col">Safari</th>
-      <th scope="col">Chrome</th>
-      <th scope="col">Safari</th>
-      <th scope="col">Chrome</th>
+      <th>Suggestions visible on reopen after close</th>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Not supported</td>
+      <td>Not supported</td>
+      <td>Not supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
     </tr>
     <tr>
+      <th>Suggestions visible on filter by input</th>
       <td>Supported</td>
       <td>Supported</td>
-      <td>Partial *</td>
+      <td>Partial: first letter entered does not always trigger</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Not supported</td>
       <td>Supported</td>
       <td>Supported</td>
       <td>Supported</td>
@@ -828,58 +761,35 @@ Testing results as of `2022-05-10`:
       <td>Supported</td>
       <td>Supported</td>
       <td>Supported</td>
-      <td>Partial **</td>
       <td>Supported</td>
     </tr>
-  </tbody>
-</table>
-</div>
-
-`*` JAWS on Firefox will sometimes not read number of suggestions until you remove characters
-
-`**` Voiceover on Safari will sometimes stop relaying updates to number of suggestions.
-
-<div class="table-wrapper" tabindex="0">
-<table>
-  <caption>Screen reader is notified when no suggestions remain</caption>
-  <colgroup span="3"></colgroup>
-  <colgroup span="2"></colgroup>
-  <colgroup span="3"></colgroup>
-  <colgroup span="1"></colgroup>
-  <colgroup span="1"></colgroup>
-  <colgroup span="2"></colgroup>
-  <colgroup span="2"></colgroup>
-  <tbody>
     <tr>
-      <th colspan="3" scope="colgroup">JAWS</th>
-      <th colspan="2" scope="colgroup">Narrator</th>
-      <th colspan="3" scope="colgroup">NVDA</th>
-      <th colspan="1" scope="colgroup">Orca</th>
-      <th colspan="1" scope="colgroup">TalkBack</th>
-      <th colspan="2" scope="colgroup">VoiceOver (iOS)</th>
-      <th colspan="2" scope="colgroup">VoiceOver (macOS)</th>
+      <th>All suggestions are hidden by filter</th>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Not supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
+      <td>Supported</td>
     </tr>
     <tr>
-      <th scope="col">Chrome</th>
-      <th scope="col">Edge</th>
-      <th scope="col">Firefox</th>
-      <th scope="col">Chrome</th>
-      <th scope="col">Edge</th>
-      <th scope="col">Chrome</th>
-      <th scope="col">Edge</th>
-      <th scope="col">Firefox</th>
-      <th scope="col">Firefox</th>
-      <th scope="col">Chrome</th>
-      <th scope="col">Safari</th>
-      <th scope="col">Chrome</th>
-      <th scope="col">Safari</th>
-      <th scope="col">Chrome</th>
-    </tr>
-    <tr>
+      <th><pre>textContent</pre> is displayed</th>
       <td>Supported</td>
       <td>Supported</td>
+      <td>Partial: first letter entered does not always trigger load-state</td>
       <td>Supported</td>
       <td>Supported</td>
+      <td>Not supported</td>
       <td>Supported</td>
       <td>Supported</td>
       <td>Supported</td>

--- a/packages/core-suggest/readme.md
+++ b/packages/core-suggest/readme.md
@@ -464,6 +464,7 @@ mySuggest.highlight = 'on' | 'off' | 'keep'          // Set highlight strategy
 mySuggest.hidden = false                             // Set hidden value
 // Methods
 mySuggest.escapeHTML('<span>...</span>')             // Utility function for escaping HTML string
+mySuggest.pushToLiveRegion('Message to be read')     // Sends string content to aria-live region to notify screen readers
 ```
 
 ### React / Preact

--- a/packages/core-suggest/readme.md
+++ b/packages/core-suggest/readme.md
@@ -127,28 +127,34 @@ Modify the default notifications announced to screen readers when suggestions ar
 
 #### Ajax
 
-Ajax requests can be stopped by calling `event.preventDefault()` on `'suggest.filter'`. Remember to always escape html and debounce requests when fetching data from external sources. The http request sent by `@nrk/core-suggest` will have header `X-Requested-With: XMLHttpRequest` for easier [server side detection and CSRF prevention](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html).
+Ajax requests can be stopped by calling `event.preventDefault()` on the [`suggest.filter` event](#suggest-filter).
 
-Note: When using `@nrk/core-suggest` with the `ajax: https://search.com?q={{value}}` functionality, make sure to implement both a `Searching...` status (while fetching data from the server), and a `No hits` status (if server responds with no results). These status indicators are highly recommended, but not provided by default as the context of use will affect the optimal textual formulation. [See example implementation →](#example-ajax)
+If you need to alter default headers, request method or post data, use the [`suggest.ajax.beforeSend` event](#input-ajax-beforesend)
 
-If you need to alter default headers, request method or post data, use the [`suggest.ajax.beforeSend` event →](#input-ajax-beforesend)
+Always [escape html](#security) and debounce requests when fetching data from external sources. The http request sent by `@nrk/core-suggest` will have header `X-Requested-With: XMLHttpRequest` for easier [server side detection and CSRF prevention](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html).
+
+When using `@nrk/core-suggest` with the `ajax` functionality, make sure to implement both a "pending" (e.g. `Searching...`) and "nothing found" (e.g. `No results`) status. Use `data-sr-read-text-content` and wrap the message with `span tabindex="-1"` instead of `button`/`a` for users to be able to interact using keyboard, but not be announced as a result to screen readers
+
+Note: These status indicators are highly recommended, but are not provided by default as the context will affect the optimal textual formulation.
 
 ```html
 <!--demo-->
 <input id="my-input-ajax" placeholder="Country..." />
 <core-suggest
   ajax="https://restcountries.com/v2/name/{{value}}?fields=name"
+  data-sr-read-text-content
   hidden
 ></core-suggest>
-<script>
+<script type="text/javascript">
   document.addEventListener("suggest.filter", (event) => {
     const suggest = event.target;
     const input = suggest.input;
     const value = input.value.trim();
 
     if (input.id !== "my-input-ajax") return; // Make sure we are on correct input
+    // Use tabindex for users to be able to reach with keyboard, but not be announced as a result to screen readers
     suggest.innerHTML = value
-      ? `<ul><li><button>Searching for ${value}...</button></li></ul>`
+      ? `<ul><li><span tabindex="-1">Searching for ${value}...</span></li></ul>`
       : "";
   });
   document.addEventListener("suggest.ajax", (event) => {
@@ -167,7 +173,7 @@ If you need to alter default headers, request method or post data, use the [`sug
               )}</button></li>`;
             }) // Generate list
             .join("")
-        : "<li><button>No results</button></li>"
+        : '<li><span tabindex="-1">No results</span></li>'
     }</ul>`;
   });
   document.addEventListener("suggest.ajax.error", (event) => {
@@ -175,9 +181,9 @@ If you need to alter default headers, request method or post data, use the [`sug
     const input = suggest.input;
 
     if (input.id !== "my-input-ajax") return; // Make sure we are on correct input
-    console.log(event);
+
     const items = event.detail.responseJSON;
-    suggest.innerHTML = "<ul><li><button>No results</button></li></ul>";
+    suggest.innerHTML = '<ul><li><span tabindex="-1">No results</span></li></ul>';
   });
 </script>
 ```
@@ -295,16 +301,20 @@ Synchronous operation; dynamically populate items based on input value:
 
 #### Ajax
 
-Ajax requests can be stopped by calling `event.preventDefault()` on `'suggest.filter'`. Remember to always escape html and debounce requests when fetching data from external sources. The http request sent by `@nrk/core-suggest` will have header `X-Requested-With: XMLHttpRequest` for easier [server side detection and CSRF prevention](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html).
+Ajax requests can be stopped by calling `event.preventDefault()` on the [`onSuggestFilter` event](#suggest-filter).
 
-Note: When using `@nrk/core-suggest` with the `ajax: https://search.com?q={{value}}` functionality, make sure to implement both a `Searching...` status (while fetching data from the server), and a `No hits` status (if server responds with no results). These status indicators are highly recommended, but not provided by default as the context of use will affect the optimal textual formulation. [See example implementation →](#example-ajax)
+If you need to alter default headers, request method or post data, use the [`onSuggestAjaxBeforeSend` event](#input-ajax-beforesend)
 
-If you need to alter default headers, request method or post data, use the [`suggest.ajax.beforeSend` event →](#input-ajax-beforesend)
+Always [escape html](#security) and debounce requests when fetching data from external sources. The http request sent by `@nrk/core-suggest` will have header `X-Requested-With: XMLHttpRequest` for easier [server side detection and CSRF prevention](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html).
+
+When using `@nrk/core-suggest` with the `ajax` functionality, make sure to implement both a "pending" (e.g. `Searching...`) and "nothing found" (e.g. `No results`) status. Use `data-sr-read-text-content={true}` and wrap the message with `span tabindex="-1"` instead of `button`/`a` for users to be able to interact using keyboard, but not be announced as a result to screen readers
+
+Note: These status indicators are highly recommended, but are not provided by default as the context will affect the optimal textual formulation.
 
 ```html
 <!--demo-->
 <div id="jsx-input-ajax"></div>
-<script type="text/jsx">
+<script type="text/javascript">
   class AjaxInput extends React.Component {
     constructor (props) {
       super(props)
@@ -331,6 +341,7 @@ If you need to alter default headers, request method or post data, use the [`sug
             ajax="https://restcountries.com/v3.1/name/{{value}}?fields=name"
             onSuggestFilter={this.onFilter}
             onSuggestAjax={this.onAjax}
+            data-sr-read-text-content={true}
           >
             <ul>
               {this.state.items.slice(0, 10).map((item) =>

--- a/packages/core-suggest/readme.md
+++ b/packages/core-suggest/readme.md
@@ -181,7 +181,7 @@ Synchronous operation; dynamically populate items based on input value:
 ```html
 <!--demo-->
 <input id="my-input-dynamic" placeholder="Type to generate suggestions">
-<core-suggest hidden filter-disabled>
+<core-suggest hidden>
   <ul></ul>
 </core-suggest>
 <script>
@@ -424,7 +424,6 @@ Text sent to screen readers can be adjusted by setting the following attributes 
 <core-suggest limit="{Number}"                          <!-- Optional. Limit maxium number of result items. Defaults to Infinity -->
               ajax="{String}"                           <!-- Optional. Fetches external data. See event 'suggest.ajax'. Example: 'https://search.com?q={{value}}' -->
               highlight="{'on' | 'off' | 'keep'}"       <!-- Optional override of highlighting matches in results. Defaults to 'on'. -->
-              filter-disabled                           <!-- Optional. Disables built-in filtering of content from input value. Useful when you want to perform filtering yourself -->
               live-region-shown-label                   <!-- Optional. Override text sent to aria-live region when suggestions are shown -->
               live-region-empty-label                   <!-- Optional. Override text sent to aria-live region when suggestions are empty due to filter -->
               live-region-count-label                   <!-- Optional. Override text sent to aria-live region when suggestions are counted as part of filtering -->
@@ -503,7 +502,7 @@ Putting the input directly before the suggestion list is highly recommended, as 
 ## Events
 
 ### suggest.filter
-Fired before a default filtering occurs:
+Fired before a default filtering occurs. If you wish to handle filtering yourself, e.g fuzzy search or similar, use `event.preventDefault()` to disable the default filtering.
 
 ```js
 document.addEventListener('suggest.filter', (event) => {

--- a/packages/core-suggest/readme.md
+++ b/packages/core-suggest/readme.md
@@ -298,7 +298,7 @@ Ajax requests can be stopped by calling `event.preventDefault()` on `'suggest.fi
 ```html
 <!--demo-->
 <input id="my-input-ajax" placeholder="Country...">
-<core-suggest ajax="https://restcountries.eu/rest/v2/name/{{value}}?fields=name" hidden></core-suggest>
+<core-suggest ajax="https://restcountries.com/v2/name/{{value}}?fields=name" hidden></core-suggest>
 <script>
   document.addEventListener('suggest.filter', (event) => {
     const suggest = event.target
@@ -346,7 +346,7 @@ Ajax requests can be stopped by calling `event.preventDefault()` on `'suggest.fi
       return <div>
         <input type='text' placeholder='Country... (JSX)' />
         <CoreSuggest
-         ajax="https://restcountries.eu/rest/v2/name/{{value}}?fields=name"
+         ajax="https://restcountries.com/v2/name/{{value}}?fields=name"
          onSuggestFilter={this.onFilter}
          onSuggestAjax={this.onAjax}>
           <ul>
@@ -375,7 +375,7 @@ Hybrid solution; lazy load items, but let `core-suggest` still handle filtering:
 <script>
   window.getCountries = (callback) => {
     const xhr = new XMLHttpRequest()
-    const url = 'https://restcountries.eu/rest/v2/?fields=name'
+    const url = 'https://restcountries.com/v2/?fields=name'
 
     xhr.onload = () => callback(JSON.parse(xhr.responseText))
     xhr.open('GET', url, true)

--- a/packages/core-suggest/readme.md
+++ b/packages/core-suggest/readme.md
@@ -105,7 +105,8 @@ VALUE | BEHAVIOUR
        list="{String}">                                 <!-- Optional. Specify id of suggest element -->
 <core-suggest limit="{Number}"                          <!-- Optional. Limit maxium number of result items. Defaults to Infinity -->
               ajax="{String}"                           <!-- Optional. Fetches external data. See event 'suggest.ajax'. Example: 'https://search.com?q={{value}}' -->
-              highlight="{'on' | 'off' | 'keep'}"       <!-- Optional override of highlighting matches in results. Defaults to 'on'.  -->
+              highlight="{'on' | 'off' | 'keep'}"       <!-- Optional override of highlighting matches in results. Defaults to 'on'. -->
+              filter-disabled                           <!-- Optional. Disables built-in filtering of content from input value. Useful when you want to perform filtering yourself -->
               hidden>                                   <!-- Use hidden to toggle visibility -->
   <ul>                                                  <!-- Can be any tag, but items should be inside <li> -->
     <li><button>Item 1</button></li>                    <!-- Items must be <button> or <a> -->

--- a/packages/core-suggest/readme.md
+++ b/packages/core-suggest/readme.md
@@ -118,26 +118,34 @@ If you need to alter default headers, request method or post data, use the [`sug
 ```html
 <!--demo-->
 <input id="my-input-ajax" placeholder="Country...">
-<core-suggest ajax="https://restcountries.com/v2/name/{{value}}?fields=name" hidden><ul></ul></core-suggest>
+<core-suggest ajax="https://restcountries.com/v2/name/{{value}}?fields=name" hidden></core-suggest>
 <script>
   document.addEventListener('suggest.filter', (event) => {
     const suggest = event.target
     const input = suggest.input
-    const list = suggest.firstElementChild
     const value = input.value.trim()
 
     if (input.id !== 'my-input-ajax') return // Make sure we are on correct input
-    list.innerHTML = value ? `<li><button>Searching for ${value}...</button></li>` : ''
+    suggest.innerHTML = value ? `<ul><li><button>Searching for ${value}...</button></li></ul>` : ''
   })
   document.addEventListener('suggest.ajax', (event) => {
     const suggest = event.target
     const input = suggest.input
-    const list = suggest.firstElementChild
+
     if (input.id !== 'my-input-ajax') return // Make sure we are on correct input
     const items = event.detail.responseJSON
-    list.innerHTML = `${items.length ? items.slice(0, 10)
-      .map((item) => { return `<li><button>${suggest.escapeHTML(item.name)}</button></li>` })           // Generate list
-      .join('') : '<li><button>No results</button></li>'}`
+    suggest.innerHTML = `<ul>${items.length ? items.slice(0, 10)
+      .map((item) => { return `<li><button>${suggest.escapeHTML(item.name)}</button></li>` }) // Generate list
+      .join('') : '<li><button>No results</button></li>'}</ul>`
+  })
+  document.addEventListener('suggest.ajax.error', (event) => {
+    const suggest = event.target
+    const input = suggest.input
+
+    if (input.id !== 'my-input-ajax') return // Make sure we are on correct input
+    console.log(event)
+    const items = event.detail.responseJSON
+    suggest.innerHTML = '<ul><li><button>No results</button></li></ul>'
   })
 </script>
 ```
@@ -147,7 +155,7 @@ Hybrid solution; lazy load items, use `core-suggest` to handle filtering:
 ```html
 <!--demo-->
 <input id="my-input-lazy" placeholder="Filter lazy-loaded content">
-<core-suggest hidden><ul></ul></core-suggest>
+<core-suggest hidden></core-suggest>
 <script>
   window.getCountries = (callback) => {
     const xhr = new XMLHttpRequest()
@@ -162,13 +170,12 @@ Hybrid solution; lazy load items, use `core-suggest` to handle filtering:
     if (event.target.id !== 'my-input-lazy') return // Make sure we are on correct input
     const input = event.target
     const suggest = input.nextElementSibling
-    const list = suggest.firstElementChild
 
     input.id = '' // Prevent double execution
     window.getCountries((items) => {
-      list.innerHTML = items.map((item) =>
+      suggest.innerHTML = `<ul>${items.map((item) =>
         '<li><button>' + suggest.escapeHTML(item.name?.common) + '</button></li>'
-      ).join('')
+      ).join('')}</ul>`
     })
   }, true)
 </script>
@@ -181,22 +188,19 @@ Synchronous operation; dynamically populate items based on input value:
 ```html
 <!--demo-->
 <input id="my-input-dynamic" placeholder="Type to generate suggestions">
-<core-suggest hidden>
-  <ul></ul>
-</core-suggest>
+<core-suggest hidden></core-suggest>
 <script>
   document.addEventListener('suggest.filter', (event) => {
     const suggest = event.target
-    const list = suggest.firstElementChild
     const input = suggest.input
     const value = input.value.trim()
     const mails = ['facebook.com', 'gmail.com', 'hotmail.com', 'mac.com', 'mail.com', 'msn.com', 'live.com']
 
     if (input.id !== 'my-input-dynamic') return // Make sure we are on correct input
     event.preventDefault()
-    list.innerHTML = `${value ? mails.map((mail) => {
+    suggest.innerHTML = `<ul>${value ? mails.map((mail) => {
       return '<li><button type="button">' + value.replace(/(@.*|$)/, '@' + mail) + '</button></li>'
-    }).join('') : ''}`
+    }).join('') : ''}</ul>`
   })
 </script>
 ```

--- a/packages/core-suggest/readme.md
+++ b/packages/core-suggest/readme.md
@@ -222,9 +222,6 @@ Synchronous operation; dynamically populate items based on input value:
     <label for="my-input-jsx">Search JSX</label>
     <input id='my-input-jsx' type='text' placeholder='Type something...' />
     <CoreSuggest
-      data-sr-shown-message="Suggestions shown"
-      data-sr-empty-message="No suggestions"
-      data-sr-count-message="Showing {{value}} suggestions"
       className='my-dropdown'
       hidden
     >


### PR DESCRIPTION
## What's new

 - ~~Introduced new observed attribute `empty`~~
   - ~~Reflects whether or not there are visible `a` or `button` elements as children of the suggest~~
   - ~~Rigged to behave similarly to `hidden`~~
 - `core-suggest` always has an `id` (fallback to uuid)
   - `aria-controls` is set on `input` to be more in line with [WAI-ARIA authoring practices](https://www.w3.org/TR/2017/NOTE-wai-aria-practices-1.1-20171214/examples/combobox/aria1.1pattern/listbox-combo.html) 
 - `core-suggest` creates a `span` with `aria-live="polite"` in `connectedCallback` only visible to screen-readers.
   - Span is placed inside `document.body`
 - Notify screen readers by updating `textContent` of aria-live region when:
   - `Forslag vises` - Suggestions are present (not `empty`) and visible (not `hidden`)
     - Replace default with attribute `live-region-shown-label`, turn off by setting value to empty string (`''`)
     - Supports substituting `{{value}}` in the attribute value for number of items in list.
   - `Ingen forslag` - All suggestions have been hidden by filter
     - Replace default with attribute `live-region-empty-label`, turn off by setting value to empty string (`''`)
   - `{{value}} forslag` - Suggestions have been filtered by input (`{{value}}` is substituted by the number of visible `a` or `button` elements as children of the `core-suggest`)
     - Replace default with attribute `live-region-count-label`, turn off by setting value to empty string (`''`)

 - ~~Introduced attribute `filter-disabled` by suggestion from @gesi~~
   - ~~Disables filtering of items in `onInput`, helpful when using core-suggest with fuzzy search and filtering gets in the way~~

Updates to `textContent` on aria-live-region, when visible, is done using a delay of 150 ms, to allow VoiceOver to announce more important info about the input-element before being informed of suggestions.

## Docs

 - Consolidated examples using tabs for plain JS and React respectively
 - Fixed lazy and ajax examples consistently getting 404 from old API. Now using https://restcountries.com 
 - Added examples for aria-live-region
 - Added section on aria-live region with info on defaults ~~and how to customize with caveat to use of `innerHTML`~~

## Next steps

~~Open for input on how to fix the caveat where setting `innerHTML` on `core-suggest`-element is never sent to SRs. So far just moving the update to a child-element seems to work fine. React/Svelte/Vue/Angular authoring practices are not affected by this (usually map items inside `<ul>` anyway).~~ -> No longer an issue with _ariaLiveSpan being moved to body.

This change requires manual testing of intended behaviour across various devices and screen-readers (SRs). In development testing/verification has been done using Google Chrome and Safari with VoiceOver.

~~We will also test whether the `role="combobox"` is necessary for iOS still, and if it may be helpful for other devices or SRs. As the implementation is not in line with the FAQ-section of the docs.~~ -> So far, testing indicates we can once more use combobox for all instances, not just for iOS.

Resolves https://github.com/nrkno/core-components/issues/642