### PR TITLE
Tabindex

### DIFF
--- a/packages/core-dialog/core-dialog.js
+++ b/packages/core-dialog/core-dialog.js
@@ -1,10 +1,6 @@
 import { closest, dispatchEvent, toggleAttribute, queryAll } from '../utils'
 
-const NATIVE_FOCUSABLE = 'a,button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),summary,audio,video,iframe,area,[contenteditable],[draggable]'
-// All native focusable plus tabindex with ordered values
-const KEYBOARD_FOCUSABLE = `[tabindex]:not([tabindex^="-"]),${NATIVE_FOCUSABLE}`
-// All native and programatic
-const PROGRAMATIC_FOCUSABLE = `[tabindex],${NATIVE_FOCUSABLE}`
+const FOCUSABLE = '[tabindex],a,button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),summary,audio,video,iframe,area,[contenteditable],[draggable]'
 const BACKDROP_OFF = 'off'
 const BACKDROP_ON = 'on'
 const KEY = {
@@ -145,12 +141,13 @@ function reFocus (el) {
 
 function setInitialFocus (el) {
   if (el.contains(document.activeElement) || !isVisible(el)) return // Do not move if focus is already inside
-  const focusable = queryAll('[autofocus]', el).concat(queryAll(PROGRAMATIC_FOCUSABLE, el)).filter(isVisible)[0]
+  const focusable = queryAll('[autofocus]', el).concat(queryAll(FOCUSABLE, el)).filter(isVisible)[0]
   try { focusable.focus() } catch (err) { console.warn(el, 'is initialized without focusable elements. Please add [tabindex="-1"] the main element (for instance a <h1>)') }
 }
 
 function keepFocus (el, event) {
-  const focusable = queryAll(KEYBOARD_FOCUSABLE, el).filter(isVisible)
+  // Filter from focusable selection to avoid selecting hidden or tabindex="-1", getting tabbable elements
+  const focusable = queryAll(FOCUSABLE, el).filter(el => el.tabindex >= 0 && isVisible(el))
   const onEdge = focusable[event.shiftKey ? 0 : focusable.length - 1]
 
   // If focus moves us outside the dialog, we need to refocus to inside the dialog

--- a/packages/core-dialog/core-dialog.js
+++ b/packages/core-dialog/core-dialog.js
@@ -1,6 +1,10 @@
 import { closest, dispatchEvent, toggleAttribute, queryAll } from '../utils'
 
-const FOCUSABLE = '[tabindex],a,button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled])'
+const NATIVE_FOCUSABLE = 'a,button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),summary,audio,video,iframe,area,[contenteditable],[draggable]'
+// All native focusable plus tabindex with ordered values
+const KEYBOARD_FOCUSABLE = `[tabindex]:not([tabindex^="-"]),${NATIVE_FOCUSABLE}`
+// All native and programatic
+const PROGRAMATIC_FOCUSABLE = `[tabindex],${NATIVE_FOCUSABLE}`
 const BACKDROP_OFF = 'off'
 const BACKDROP_ON = 'on'
 const KEY = {
@@ -141,12 +145,12 @@ function reFocus (el) {
 
 function setFocus (el) {
   if (el.contains(document.activeElement) || !isVisible(el)) return // Do not move if focus is already inside
-  const focusable = queryAll('[autofocus]', el).concat(queryAll(FOCUSABLE, el)).filter(isVisible)[0]
+  const focusable = queryAll('[autofocus]', el).concat(queryAll(PROGRAMATIC_FOCUSABLE, el)).filter(isVisible)[0]
   try { focusable.focus() } catch (err) { console.warn(el, 'is initialized without focusable elements. Please add [tabindex="-1"] the main element (for instance a <h1>)') }
 }
 
 function keepFocus (el, event) {
-  const focusable = queryAll(FOCUSABLE, el).filter(isVisible)
+  const focusable = queryAll(KEYBOARD_FOCUSABLE, el).filter(isVisible)
   const onEdge = focusable[event.shiftKey ? 0 : focusable.length - 1]
 
   // If focus moves us outside the dialog, we need to refocus to inside the dialog

--- a/packages/core-dialog/core-dialog.js
+++ b/packages/core-dialog/core-dialog.js
@@ -56,7 +56,7 @@ export default class CoreDialog extends HTMLElement {
           this.style.zIndex = zIndex + 2
         }
         this._focus = document.activeElement || document.body // Remember last focused element
-        setTimeout(() => setFocus(this)) // Move focus after paint (helps iOS and react portals)
+        setTimeout(() => setInitialFocus(this)) // Move focus after paint (helps iOS and react portals)
       }
       // React might re-mount the DOM, so make sure prev and next did actually change
       if (attr === 'hidden' && next !== prev) dispatchEvent(this, 'dialog.toggle')
@@ -67,7 +67,7 @@ export default class CoreDialog extends HTMLElement {
     if (event.defaultPrevented) return
     const { type, key, target } = event
 
-    if (type === 'transitionend' && target === this && !this.hidden) setFocus(this) // Move focus after transition
+    if (type === 'transitionend' && target === this && !this.hidden) setInitialFocus(this) // Move focus after transition
     else if (type === 'click') {
       if (target === this.backdrop && !this.strict) return this.close() // Click on backdrop
       const button = closest(target, 'button')
@@ -143,7 +143,7 @@ function reFocus (el) {
   })
 }
 
-function setFocus (el) {
+function setInitialFocus (el) {
   if (el.contains(document.activeElement) || !isVisible(el)) return // Do not move if focus is already inside
   const focusable = queryAll('[autofocus]', el).concat(queryAll(PROGRAMATIC_FOCUSABLE, el)).filter(isVisible)[0]
   try { focusable.focus() } catch (err) { console.warn(el, 'is initialized without focusable elements. Please add [tabindex="-1"] the main element (for instance a <h1>)') }

--- a/packages/core-dialog/readme.md
+++ b/packages/core-dialog/readme.md
@@ -355,8 +355,7 @@ import CoreDialog from '@nrk/core-dialog/jsx'
 
 ### Required focusable element
 
-Your dialog must contain `<input>`, `<button>`, `<select>`, `<textarea>`, `<a>`
-or element with `tabindex="-1"` to ensure the user is navigated into the `<core-dialog>`.
+Your dialog must contain a tabbable element (e.g. visible `<input>`, `<button>`, `<select>`, `<textarea>`, `<a>`, `<summary>`, `<audio>`, `<video>`, `<iframe>`, `<area>` or with the `contenteditable` or `draggable` attributes) or a focusable element (with `tabindex="-1"`) to ensure the users focus is navigated into the `<core-dialog>`.
 As a best practice; if your dialog contains a form element, use `autofocus`.
 If you dialog is without form elements, start your dialog
 content with `<h1 tabindex="-1">Dialog title</h1>`.


### PR DESCRIPTION
Differentiate between focusable elements:
* Native focusable elements updated to match spec
* Programatic focus (all native plus any set `tabindex`)
* Keyboard focus (all native plus nun-negative `tabindex` values)

Use programatic focus selection for initial focus, use keyboard focus selector when keeping focus inside dialog

Resolves #645 