### PR TITLE
Adding check for null-values in onMutation

### DIFF
--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -202,7 +202,7 @@ function toggleItem (item, show) {
 function onMutation (self) {
   if (!self._observer) return // Abort if disconnectedCallback has been called (this/self._observer is null)
 
-  const needle = self.input.value.toLowerCase().trim()
+  const needle = (self.input && self.input.value) ? self.input.value.toLowerCase().trim() : null
   const items = self.querySelectorAll('a:not([hidden]),button:not([hidden])')
   const limit = Math.min(items.length, self.limit)
 


### PR DESCRIPTION
Keep getting this error when using core-suggest in React and the parent component re-render.
```
Uncaught TypeError: Cannot read properties of undefined (reading 'toLowerCase') 
at onMutation
```
Added a null safeguard to prevent it.