### PR TITLE
Core toggle outside viewport

### DIFF
--- a/packages/core-toggle/autoposition.html
+++ b/packages/core-toggle/autoposition.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<head>
+  <link rel="stylesheet" href="https://static.nrk.no/nrk-sans/latest/nrk-sans.min.css">
+</head>
+<script src="https://unpkg.com/@webcomponents/custom-elements"></script>
+<script src="core-toggle.min.js"></script>
+<!-- <script src="core-toggle.jsx.js"></script> -->
+<style>
+  
+  html { height: 400px; }
+  html * {
+    font-family: 'NRK Sans Variable', sans-serif;    
+  }
+  h1 {
+    font-size: 1em;
+    text-decoration: none;
+  }
+  .left-right {
+    display: flex;
+  }
+  .centered {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+  .my-dropdown {
+    background-color: aliceblue;
+    border: 1px solid darkblue;
+    border-radius: 5px;
+    white-space: nowrap;
+  }
+  core-toggle {
+    padding-right: 10px;
+  }
+</style>
+
+<div class="container">
+  <h1>Toggled content is anchored left or right if there is room to draw</h1>
+  <div class="left-right">
+    <button type="button">Autopositioned toggle</button>
+    <core-toggle class="my-dropdown" data-popup autoposition hidden>
+      <ul>
+        <li>
+          Fits inside window
+        </li>
+        <li>
+          Has room to the right
+        </li>
+        <li>
+          Anchored left of button
+        </li>
+      </ul>
+    </core-toggle>
+    <button type="button">Autopositioned toggle</button>
+    <core-toggle class="my-dropdown" data-popup autoposition hidden>
+      <ul>
+        <li>
+          Fits inside window
+        </li>
+        <li>
+          Has room to the left
+        </li>
+        <li>
+          Anchored right of button
+        </li>
+      </ul>
+    </core-toggle>
+  </div>
+  <div class="centered">
+    <h1>Toggled content is centered if there is no room to either side</h1>
+    <button type="button">Autoposition toggle</button>
+    <core-toggle class="my-dropdown" data-popup autoposition hidden>
+      <ul>
+        <li>
+          Fits inside window
+        </li>
+        <li>
+          Can't fully draw left or right
+        </li>
+        <li>
+          Centered on screen
+        </li>
+      </ul>
+    </core-toggle>
+  </div>
+  <h1>Toggled content wider than screen width</h1>
+  <button type="button">Autoposition toggle</button>
+  <core-toggle class="my-dropdown" data-popup autoposition hidden>
+    <ul>
+      <li>
+        Too looooooooooooooooooooooooonooooooooooooooooooooooooong
+      </li>
+      <li>
+        Anchored to left screen side
+      </li>
+      <li>
+        Try to display as much as possible
+      </li>
+    </ul>
+  </core-toggle>
+  <h1>Toggled content too close to bottom of screen</h1>
+  <div class="left-right">
+    <button type="button">Autopositioned toggle</button>
+    <core-toggle class="my-dropdown" data-popup autoposition hidden>
+      <ul>
+        <li>
+          Fits inside window
+        </li>
+        <li>
+          Has room to the right
+        </li>
+        <li>
+          Has room above
+        </li>
+        <li>
+          Anchored left of button
+        </li>
+        <li>
+          Drawn above toggle
+        </li>
+      </ul>
+    </core-toggle>
+    <button type="button">Autopositioned toggle</button>
+    <core-toggle class="my-dropdown" data-popup autoposition hidden>
+      <ul>
+        <li>
+          Fits inside window
+        </li>
+        <li>
+          Has room to the left
+        </li>
+        <li>
+          Has room above
+        </li>
+        <li>
+          Anchored right of button
+        </li>
+        <li>
+          Drawn above toggle
+        </li>
+      </ul>
+    </core-toggle>
+  </div>
+</div>

--- a/packages/core-toggle/core-toggle.js
+++ b/packages/core-toggle/core-toggle.js
@@ -65,14 +65,24 @@ export default class CoreToggle extends HTMLElement {
     const contentRect = this.getBoundingClientRect()
 
     const hasSpaceRight = triggerRect.left + contentRect.width < window.innerWidth
+    const hasSpaceLeft = triggerRect.right - contentRect.width >= 0
     const hasSpaceUnder = triggerRect.bottom + contentRect.height < window.innerHeight
     const hasSpaceOver = triggerRect.top - contentRect.height > 0
+
+    let leftVal = Math.round((window.innerWidth - contentRect.width) / 2) // Center on screen
+    if (contentRect.width > window.innerWidth) {
+      leftVal = 0 // Content wider than screen. Anchor to left screen edge to show as much as possible
+    } else if (hasSpaceRight) {
+      leftVal = triggerRect.left // Anchor to left side
+    } else if (hasSpaceLeft) {
+      leftVal = triggerRect.right - contentRect.width // Anchor to right side
+    }
 
     // Always place under when no hasSpaceOver, as no OS can scroll further up than window.scrollY = 0
     const placeUnder = hasSpaceUnder || !hasSpaceOver
     const scroll = placeUnder ? window.pageYOffset + triggerRect.bottom + contentRect.height + 30 : 0
 
-    this.style.left = `${Math.round(hasSpaceRight ? triggerRect.left : triggerRect.right - contentRect.width)}px`
+    this.style.left = `${leftVal}px`
     this.style.top = `${Math.round(placeUnder ? triggerRect.bottom : triggerRect.top - contentRect.height)}px`
     SCROLLER.style.cssText = `position:absolute;padding:1px;top:${Math.round(scroll)}px`
     setTimeout(() => (this._skipPosition = null)) // Timeout to flush event queue before we can resume acting on mutations

--- a/packages/core-toggle/readme.md
+++ b/packages/core-toggle/readme.md
@@ -39,7 +39,7 @@ demo-->
 ```html
 <!--demo-->
 <div id="jsx-toggle-popup"></div>
-<script type="text/jsx">
+<script type="text/javascript">
   ReactDOM.render(<>
     <button type="button">Popup JSX</button>
     <CoreToggle className='my-dropdown' hidden data-popup onToggleSelect={console.warn}>
@@ -160,22 +160,13 @@ If you have form elements inside a `<core-toggle>`, you can optionally add a `au
 
 ### Autoposition
 
-When using core-toggle near the screen edges, the `autoposition` attribute positions the toggled content where there is visual room around the button, using `position:fixed`.
-This enables core-toggle to be used inside scrollable areas.
+When using core-toggle near the screen edges, the `autoposition` attribute positions the toggled content where there is visual room around the toggle, using `position:fixed`, relative to the screen edges.
+This can be useful when core-toggle is used inside narrow and/or scrollable areas.
 
 ```html
 <!--demo-->
-<div style="overflow:auto; height:70px; width:200px; border:2px dashed #ccc;">
-  <button type="button">Toggle is autopositioned</button>
-  <core-toggle class="my-dropdown" autoposition hidden>
-    <ul>
-      <li><a>Link</a></li>
-      <li><a>Another link</a></li>
-      <li><a>Linking is life</a></li>
-    </ul>
-  </core-toggle>
-  <p>Scroll me to the edge!</p>
-</div>
+<p>This example illustrates how core-toggle with <code style="font-size: 16px">autoposition</code> draws relative to the screen edge marked by the red frame</p>
+<iframe src="core-toggle/autoposition.html" width="300" height="400" style="border: 2px solid red;"></iframe>
 ```
 ## Events
 
@@ -270,7 +261,7 @@ to create a component that behaves like a `<select>`:
 ```html
 <!--demo-->
 <div id="jsx-toggle-select"></div>
-<script type="text/jsx">
+<script type="text/javascript">
   class MyToggleSelect extends React.Component {
     constructor (props) {
       super(props)


### PR DESCRIPTION
Reworked autopositioning logic for core-toggle.
 * Check for room in all directions to avoid drawing outside viewport
 * Handle toggled content larger than viewport
 * Default to centering (horizontally) on screen if there is no room to draw fully to either left or right

Resolves #648 

Improved docs section to illustrate effects of `autoposition`

![Screenshot 2022-08-24 at 11 36 50](https://user-images.githubusercontent.com/2345608/186389146-2d52d2a0-fed5-4fe7-af80-e841b28471ad.png)
![Screenshot 2022-08-24 at 11 36 59](https://user-images.githubusercontent.com/2345608/186389153-01241563-d301-4970-8346-ef40a8988232.png)
![Screenshot 2022-08-24 at 11 37 09](https://user-images.githubusercontent.com/2345608/186389157-e88d9928-4fee-45a2-840e-689e7476d957.png)
![Screenshot 2022-08-24 at 11 37 22](https://user-images.githubusercontent.com/2345608/186389161-ef449ae2-8bfb-4e7d-8aeb-fb0abbd372ff.png)
![Screenshot 2022-08-24 at 11 37 31](https://user-images.githubusercontent.com/2345608/186389164-a45a96b5-5332-48bb-98aa-750c3be4d510.png)
![Screenshot 2022-08-24 at 11 37 48](https://user-images.githubusercontent.com/2345608/186389166-63f0aab2-8597-4924-93a8-cbc64d1f4b12.png)

