### PR TITLE
Core-suggest filter on select

### DIFF
--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -268,15 +268,27 @@ function onMutation (self) {
 
 /**
  * Handle input event in connected input
- * Performs filtering of core-suggest items
- * Dispatches event
- *  * `suggest.filter`
  * @param {CoreSuggest} self Core suggest element
  * @param {InputEvent} event
  * @returns {void}
  */
 function onInput (self, event) {
-  if (event.target !== self.input || !dispatchEvent(self, 'suggest.filter') || onAjax(self)) return
+  if (event.target !== self.input) return
+  filterItemsByInput(self)
+}
+
+/**
+ * Performs filtering of core-suggest items
+ * Dispatches event
+ *  * `suggest.filter`
+ * Filtering is aborted if
+ *  * event.preventDefault() is called on on `suggest.filter` event
+ *  * core-suggest element has attribute `ajax`
+ * @param {CoreSuggest} self Core suggest element
+ * @fires `suggest.filter`
+ */
+function filterItemsByInput (self) {
+  if (!dispatchEvent(self, 'suggest.filter') || onAjax(self)) return
   const value = self.input.value.toLowerCase()
   const items = self.querySelectorAll('a,button')
 

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -352,7 +352,7 @@ function onClick (self, event) {
 /**
  * Handle ajax event using ajax attribute
  * @param {CoreSuggest} self Core suggest element
- * @returns {true}
+ * @returns {Boolean} Returns true if Core Suggest element has `ajax` attribute value, false if not
  */
 function onAjax (self) {
   if (!self.ajax) return

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -341,6 +341,7 @@ function onClick (self, event) {
 
   if (item && dispatchEvent(self, 'suggest.select', item)) {
     self.input.value = item.value || item.textContent.trim()
+    filterItemsByInput(self)
     self.input.focus()
   }
 

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -268,12 +268,14 @@ function onMutation (self) {
 
 /**
  * Handle input event in connected input
+ * Triggers built-in ajax functionality if `ajax`-attribute is set
+ *  * Suggestions will not be filtered by input if this is the case
  * @param {CoreSuggest} self Core suggest element
  * @param {InputEvent} event
  * @returns {void}
  */
 function onInput (self, event) {
-  if (event.target !== self.input) return
+  if (event.target !== self.input || onAjax(self)) return
   filterItemsByInput(self)
 }
 
@@ -283,12 +285,11 @@ function onInput (self, event) {
  *  * `suggest.filter`
  * Filtering is aborted if
  *  * event.preventDefault() is called on on `suggest.filter` event
- *  * core-suggest element has attribute `ajax`
  * @param {CoreSuggest} self Core suggest element
  * @fires `suggest.filter`
  */
 function filterItemsByInput (self) {
-  if (!dispatchEvent(self, 'suggest.filter') || onAjax(self)) return
+  if (!dispatchEvent(self, 'suggest.filter')) return
   const value = self.input.value.toLowerCase()
   const items = self.querySelectorAll('a,button')
 

--- a/packages/core-suggest/core-suggest.test.js
+++ b/packages/core-suggest/core-suggest.test.js
@@ -89,6 +89,25 @@ describe('core-suggest', () => {
     await expect(prop('button#three', 'hidden')).toMatch(/true/i)
   })
 
+  it('filters suggestions from input value when selecting suggestion', async () => {
+    await browser.executeScript(() => {
+      document.body.innerHTML = `
+        <input type="text">
+        <core-suggest hidden>
+          <ul>
+            <li><button id="one">Suggest 1</button></li>
+            <li><button id="two">Suggest 2</button></li>
+          </ul>
+        </core-suggest>
+      `
+    })
+    await $('input').click()
+    await $('button#two').click()
+    await expect(prop('input', 'value')).toEqual('Suggest 2')
+    await expect(prop('button#one', 'hidden')).toMatch(/true/i)
+    await expect(prop('button#two', 'hidden')).toMatch(/(null|false)/i)
+  })
+
   it('sets type="button" on all suggestion buttons', async () => {
     await browser.executeScript(() => {
       document.body.innerHTML = `

--- a/packages/utils.js
+++ b/packages/utils.js
@@ -64,10 +64,10 @@ export const closest = (() => {
 
 /**
 * dispatchEvent - with infinite loop prevention
-* @param {Element} elem The target object
-* @param {String} name The source object(s)
+* @param {Element} element The target object
+* @param {String} name The event name
 * @param {Object} detail Detail object (bubbles and cancelable is set to true)
-* @return {Boolean} Whether the event was canceled
+* @return {Boolean} Whether the event was canceled. Returns true if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise.
 */
 export function dispatchEvent (element, name, detail = {}) {
   const ignore = `prevent_recursive_dispatch_maximum_callstack${name}`


### PR DESCRIPTION
When selecting a suggestion in core-suggest, the input value is updated, but suggestions are not filtered as they would have been if users typed the same value into the input.

This PR introduces the following:
 * core-suggest filters suggestions when selecting a suggestion updates the value of the input
   * A `suggest.filter`-event is fired, as it would from user keyboard input
   * This filtering respects disabling via `event.preventDefault()` on `suggest.filter` event
   * Filtering does not occur if core-suggest has a value in the `ajax` attribute, in which case onAjax is called