### PR TITLE
fix(core-suggest): Guard for missing input value when filtering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nrk/core-components",
-  "version": "10.0.3",
+  "version": "10.0.4-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nrk/core-components",
-      "version": "10.0.3",
+      "version": "10.0.4-0",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@nrk/core-components",
   "homepage": "https://static.nrk.no/core-components/latest/",
   "author": "NRK <opensource@nrk.no> (https://www.nrk.no/)",
-  "version": "10.0.3",
+  "version": "10.0.4-0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -285,11 +285,12 @@ function onInput (self, event) {
  *  * `suggest.filter`
  * Filtering is aborted if
  *  * event.preventDefault() is called on on `suggest.filter` event
+ *  * input has no value
  * @param {CoreSuggest} self Core suggest element
  * @fires `suggest.filter`
  */
 function filterItemsByInput (self) {
-  if (!dispatchEvent(self, 'suggest.filter')) return
+  if (!dispatchEvent(self, 'suggest.filter') || !(self.input && self.input.value)) return
   const value = self.input.value.toLowerCase()
   const items = self.querySelectorAll('a,button')
 

--- a/packages/core-suggest/package-lock.json
+++ b/packages/core-suggest/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nrk/core-suggest",
-  "version": "1.3.3",
+  "version": "1.3.4-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nrk/core-suggest",
-      "version": "1.3.3",
+      "version": "1.3.4-0",
       "license": "MIT"
     }
   }

--- a/packages/core-suggest/package.json
+++ b/packages/core-suggest/package.json
@@ -2,7 +2,7 @@
   "name": "@nrk/core-suggest",
   "homepage": "https://static.nrk.no/core-components/latest/",
   "author": "NRK <opensource@nrk.no> (https://www.nrk.no/)",
-  "version": "1.3.3",
+  "version": "1.3.4-0",
   "license": "MIT",
   "main": "core-suggest.cjs.js",
   "repository": {


### PR DESCRIPTION
Add guard for missing input or input value in `filterItemsByInput`

Should help avoid typeErrors after selecting a suggestion

Resolves #658 