### PR TITLE
Fix/core suggest ignore disabled

### DIFF
--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -339,7 +339,7 @@ function onKey (self, event) {
  */
 function onClick (self, event) {
   const item = event.type === 'click' && self.contains(event.target) && closest(event.target, 'a,button')
-  const show = !item && (self.contains(event.target) || self.input === event.target)
+  const show = !item && (self.contains(event.target) || (self.input === event.target && !self.input.disabled))
 
   let delayedFilter = false
   if (item && dispatchEvent(self, 'suggest.select', item)) {

--- a/packages/core-suggest/core-suggest.test.js
+++ b/packages/core-suggest/core-suggest.test.js
@@ -28,7 +28,7 @@ describe('core-suggest', () => {
     await expect(attr('input', 'aria-expanded')).toEqual('false')
   })
 
-  it('opens suggestions on input focus', async () => {
+  it('opens suggestions on input click', async () => {
     await browser.executeScript(() => {
       document.body.innerHTML = `
         <input type="text">

--- a/packages/core-suggest/core-suggest.test.js
+++ b/packages/core-suggest/core-suggest.test.js
@@ -40,6 +40,18 @@ describe('core-suggest', () => {
     await expect(prop('core-suggest', 'hidden')).toMatch(/(null|false)/i)
   })
 
+  it('does not open suggestions on clicking a disabled input', async () => {
+    await browser.executeScript(() => {
+      document.body.innerHTML = `
+        <input type="text" disabled>
+        <core-suggest hidden></core-suggest>
+      `
+    })
+    await $('input').click()
+    await expect(attr('input', 'aria-expanded')).toEqual('false')
+    await expect(prop('core-suggest', 'hidden')).toMatch(/true/i)
+  })
+
   it('closes suggestions on click outside', async () => {
     await browser.executeScript(() => {
       document.body.innerHTML = `


### PR DESCRIPTION
Do not show core-suggest when clicking disabled input

- Added test case to verify
- Reworded test to specify that we can only verify clicking the input.

Relates to #661 