### PR TITLE
fix(utils): Add guard for undefined navigator

### DIFF
--- a/packages/utils.js
+++ b/packages/utils.js
@@ -1,6 +1,7 @@
 export const IS_BROWSER = typeof window !== 'undefined'
-export const IS_ANDROID = IS_BROWSER && /(android)/i.test(navigator.userAgent) // Bad, but needed
-export const IS_IOS = IS_BROWSER && /iPad|iPhone|iPod/.test(String(navigator.platform))
+const HAS_NAVIGATOR = IS_BROWSER && typeof window.navigator !== 'undefined'
+export const IS_ANDROID = HAS_NAVIGATOR && /(android)/i.test(navigator.userAgent) // Bad, but needed
+export const IS_IOS = HAS_NAVIGATOR && /iPad|iPhone|iPod/.test(String(navigator.platform))
 export const IS_IE11 = IS_BROWSER && window.msCrypto // msCrypto only exists in IE11
 
 // Mock HTMLElement for Node


### PR DESCRIPTION
* Verify existing `navigator` before referencing in exports from utils

There should be no discernable change for use in browsers. When running in node or similar environments without `window`, we should no longer cause a referenceError due to undefined `navigator` as reported in #660 

This change would signify a bugfix to the following packages (every package that references utils):
* core-datepicker
* core-dialog
* core-progress
* core-scroll
* core-suggest
* core-tabs
* core-toggle
