### PR TITLE
core-scroll: dispatch "scroll.change" (i.e. initialise buttons) when children change

### DIFF
--- a/packages/core-scroll/core-scroll.js
+++ b/packages/core-scroll/core-scroll.js
@@ -77,10 +77,21 @@ export default class CoreScroll extends HTMLElement {
     window.addEventListener('load', this) // Update state when we are sure all CSS is loaded
     document.addEventListener('click', this)
     setTimeout(() => this.handleEvent()) // Initialize buttons after children is parsed
+    
+    // Trigger init when childList is changed - important for jsx in regards to scroll buttons
+    this._childListObserver = new MutationObserver((mutations) => {
+      for (const mutation of mutationList) {
+        if (mutation.type === 'childList') {
+          this.handleEvent();
+        }
+      }
+    })
+    this._childListObserver.observe(this, { childList: true })
   }
 
   disconnectedCallback () {
     this._throttledEvent = null // Garbage collection
+    this._childListObserver.disconnect();
     this.removeEventListener('mousedown', this)
     this.removeEventListener('wheel', this, EVENT_PASSIVE)
     this.removeEventListener('scroll', this._throttledEvent, EVENT_PASSIVE)

--- a/packages/core-scroll/core-scroll.js
+++ b/packages/core-scroll/core-scroll.js
@@ -80,16 +80,8 @@ export default class CoreScroll extends HTMLElement {
 
     // Initialize buttons when children change
     // - jsx relies on onScrollChange triggering to update button states
-    if (!this._childListObserver && window.MutationObserver) {
-      this._childListObserver = new window.MutationObserver((mutationList) => {
-        for (const mutation of mutationList) {
-          if (mutation.type === 'childList') {
-            this.handleEvent()
-          }
-        }
-      })
-    }
-    this._childListObserver.observe(this, { childList: true, subtree: true })
+    if (!this._childListObserver && window.MutationObserver) this._childListObserver = new window.MutationObserver(onDOMchange.bind(this))
+    if (this._childListObserver) this._childListObserver.observe(this, { childList: true, subtree: true })
   }
 
   disconnectedCallback () {
@@ -270,5 +262,15 @@ function parsePoint (self, move) {
   return {
     x: Math.max(0, Math.min(point.x, self.scrollWidth - self.clientWidth)),
     y: Math.max(0, Math.min(point.y, self.scrollHeight - self.clientHeight))
+  }
+}
+
+function onDOMchange (mutationList) {
+  if (!this.parentNode) return // Abort if removed from DOM
+
+  for (const mutation of mutationList) {
+    if (mutation.type === 'childList') {
+      this.handleEvent()
+    }
   }
 }

--- a/packages/core-scroll/core-scroll.js
+++ b/packages/core-scroll/core-scroll.js
@@ -78,15 +78,16 @@ export default class CoreScroll extends HTMLElement {
     document.addEventListener('click', this)
     setTimeout(() => this.handleEvent()) // Initialize buttons after children is parsed
     
-    // Trigger init when childList is changed - important for jsx in regards to scroll buttons
-    this._childListObserver = new MutationObserver((mutations) => {
+    // Initialize buttons when children change
+    // - jsx relies on onScrollChange triggering to update button states
+    this._childListObserver = new MutationObserver((mutationList) => {
       for (const mutation of mutationList) {
         if (mutation.type === 'childList') {
           this.handleEvent();
         }
       }
     })
-    this._childListObserver.observe(this, { childList: true })
+    this._childListObserver.observe(this, { childList: true, subtree: true })
   }
 
   disconnectedCallback () {

--- a/packages/core-scroll/core-scroll.js
+++ b/packages/core-scroll/core-scroll.js
@@ -86,8 +86,7 @@ export default class CoreScroll extends HTMLElement {
 
   disconnectedCallback () {
     if (this._childListObserver) this._childListObserver.disconnect()
-    this._childListObserver = null // Garbage collection
-    this._throttledEvent = null
+    this._childListObserver = this._throttledEvent = null // Garbage collection
     this.removeEventListener('mousedown', this)
     this.removeEventListener('wheel', this, EVENT_PASSIVE)
     this.removeEventListener('scroll', this._throttledEvent, EVENT_PASSIVE)

--- a/packages/core-scroll/core-scroll.js
+++ b/packages/core-scroll/core-scroll.js
@@ -267,12 +267,36 @@ function parsePoint (self, move) {
   }
 }
 
+/**
+ * scroll.DOMChange
+ *
+ * fired when MutationObserver in CoreScroll detects a change in child nodes
+ *
+ * @event scroll.DOMChange
+ * @type {object}
+ * @param {NodeList} addedNodes
+ * @param {NodeList} removedNodes
+ */
+
+/**
+ * Handle DOM changes in childlist observed with MutationObserver in CoreScroll
+ *
+ * @this {CoreScroll} CoreScroll HTMLElement
+ * @param {MutationRecord[]} mutationList
+ * @fires scroll.DOMChange when a MutationRecord has type childList
+ */
 function onDOMchange (mutationList) {
   if (!this.parentNode) return // Abort if removed from DOM
 
   for (const mutation of mutationList) {
+    /* One or more children have been added to and/or removed from the tree. */
     if (mutation.type === 'childList') {
-      this.handleEvent()
+      const scrollStatus = getScrollStatus(this)
+      updateButtons(this, scrollStatus)
+      dispatchEvent(this, 'scroll.DOMChange', {
+        addedNodes: mutation.addedNodes,
+        removedNodes: mutation.removedNodes
+      })
     }
   }
 }

--- a/packages/core-scroll/core-scroll.js
+++ b/packages/core-scroll/core-scroll.js
@@ -76,12 +76,13 @@ export default class CoreScroll extends HTMLElement {
     window.addEventListener('resize', this._throttledEvent, EVENT_PASSIVE)
     window.addEventListener('load', this) // Update state when we are sure all CSS is loaded
     document.addEventListener('click', this)
-    setTimeout(() => this.handleEvent()) // Initialize buttons after children is parsed
 
-    // Initialize buttons when children change
-    // - jsx relies on onScrollChange triggering to update button states
+    // Observe children for changes and run this.handleEvent()
+    // - jsx in particular relies on onScrollChange triggering to update button states
     if (!this._childListObserver && window.MutationObserver) this._childListObserver = new window.MutationObserver(onDOMchange.bind(this))
     if (this._childListObserver) this._childListObserver.observe(this, { childList: true, subtree: true })
+
+    setTimeout(() => this.handleEvent()) // Initialize buttons after children is parsed
   }
 
   disconnectedCallback () {

--- a/packages/core-scroll/core-scroll.js
+++ b/packages/core-scroll/core-scroll.js
@@ -293,10 +293,7 @@ function onDOMchange (mutationList) {
     if (mutation.type === 'childList') {
       const scrollStatus = getScrollStatus(this)
       updateButtons(this, scrollStatus)
-      dispatchEvent(this, 'scroll.DOMChange', {
-        addedNodes: mutation.addedNodes,
-        removedNodes: mutation.removedNodes
-      })
+      dispatchEvent(this, 'scroll.change')
     }
   }
 }

--- a/packages/core-scroll/core-scroll.js
+++ b/packages/core-scroll/core-scroll.js
@@ -77,22 +77,25 @@ export default class CoreScroll extends HTMLElement {
     window.addEventListener('load', this) // Update state when we are sure all CSS is loaded
     document.addEventListener('click', this)
     setTimeout(() => this.handleEvent()) // Initialize buttons after children is parsed
-    
+
     // Initialize buttons when children change
     // - jsx relies on onScrollChange triggering to update button states
-    this._childListObserver = new MutationObserver((mutationList) => {
-      for (const mutation of mutationList) {
-        if (mutation.type === 'childList') {
-          this.handleEvent();
+    if (!this._childListObserver && window.MutationObserver) {
+      this._childListObserver = new window.MutationObserver((mutationList) => {
+        for (const mutation of mutationList) {
+          if (mutation.type === 'childList') {
+            this.handleEvent()
+          }
         }
-      }
-    })
+      })
+    }
     this._childListObserver.observe(this, { childList: true, subtree: true })
   }
 
   disconnectedCallback () {
-    this._throttledEvent = null // Garbage collection
-    this._childListObserver.disconnect();
+    if (this._childListObserver) this._childListObserver.disconnect()
+    this._childListObserver = null // Garbage collection
+    this._throttledEvent = null
     this.removeEventListener('mousedown', this)
     this.removeEventListener('wheel', this, EVENT_PASSIVE)
     this.removeEventListener('scroll', this._throttledEvent, EVENT_PASSIVE)

--- a/packages/core-scroll/core-scroll.jsx
+++ b/packages/core-scroll/core-scroll.jsx
@@ -3,6 +3,6 @@ import { version } from './package.json'
 import customElementToReact from '@nrk/custom-element-to-react'
 
 export default customElementToReact(CoreScroll, {
-  customEvents: ['scroll.change', 'scroll.click'],
+  customEvents: ['scroll.change', 'scroll.click', 'scroll.DOMChange'],
   suffix: version
 })

--- a/packages/core-scroll/core-scroll.jsx
+++ b/packages/core-scroll/core-scroll.jsx
@@ -3,6 +3,6 @@ import { version } from './package.json'
 import customElementToReact from '@nrk/custom-element-to-react'
 
 export default customElementToReact(CoreScroll, {
-  customEvents: ['scroll.change', 'scroll.click', 'scroll.DOMChange'],
+  customEvents: ['scroll.change', 'scroll.click'],
   suffix: version
 })

--- a/packages/core-scroll/core-scroll.test.js
+++ b/packages/core-scroll/core-scroll.test.js
@@ -132,7 +132,7 @@ describe('core-scroll', () => {
       await expect(browser.executeScript(() => document.getElementById('scroller').friction)).toEqual(0.1)
     })
 
-    it('dispatches "scroll.change" onConnected and when children are added/removed', async () => {
+    it('dispatches "scroll.change" onConnected', async () => {
       await browser.executeScript(() => {
         window.scrollEvents = []
         document.body.innerHTML = '<core-scroll id="scroller"></core-scroll>'
@@ -140,6 +140,16 @@ describe('core-scroll', () => {
       })
       // Assert single event dispatched onConnected
       await expect(browser.executeScript(() => window.scrollEvents.length)).toEqual(1)
+    })
+
+    it('dispatches "scroll.DOMChange" when children are added/removed', async () => {
+      await browser.executeScript(() => {
+        window.domChangeEvents = []
+        document.body.innerHTML = '<core-scroll id="scroller"></core-scroll>'
+        document.addEventListener('scroll.DOMChange', (event) => (window.domChangeEvents.push(event)))
+      })
+      // Assert no event dispatched onConnected
+      await expect(browser.executeScript(() => window.domChangeEvents.length)).toEqual(0)
       // Add children
       await browser.executeScript(() => {
         document.getElementById('scroller').insertAdjacentHTML('beforeend', `
@@ -150,11 +160,11 @@ describe('core-scroll', () => {
       })
 
       // Assert event dispatched for adding children
-      await expect(browser.executeScript(() => window.scrollEvents.length)).toEqual(2)
+      await expect(browser.executeScript(() => window.domChangeEvents.length)).toEqual(1)
 
       // Assert event dispatched for removing children
       await browser.executeScript(() => document.getElementById('scroller').children[0].remove())
-      await expect(browser.executeScript(() => window.scrollEvents.length)).toEqual(3)
+      await expect(browser.executeScript(() => window.domChangeEvents.length)).toEqual(2)
     })
   })
 

--- a/packages/core-scroll/core-scroll.test.js
+++ b/packages/core-scroll/core-scroll.test.js
@@ -132,7 +132,7 @@ describe('core-scroll', () => {
       await expect(browser.executeScript(() => document.getElementById('scroller').friction)).toEqual(0.1)
     })
 
-    it('dispatches "scroll.change" onConnected', async () => {
+    it('dispatches "scroll.change" onConnected and when children are added/removed', async () => {
       await browser.executeScript(() => {
         window.scrollEvents = []
         document.body.innerHTML = '<core-scroll id="scroller"></core-scroll>'
@@ -140,16 +140,6 @@ describe('core-scroll', () => {
       })
       // Assert single event dispatched onConnected
       await expect(browser.executeScript(() => window.scrollEvents.length)).toEqual(1)
-    })
-
-    it('dispatches "scroll.DOMChange" when children are added/removed', async () => {
-      await browser.executeScript(() => {
-        window.domChangeEvents = []
-        document.body.innerHTML = '<core-scroll id="scroller"></core-scroll>'
-        document.addEventListener('scroll.DOMChange', (event) => (window.domChangeEvents.push(event)))
-      })
-      // Assert no event dispatched onConnected
-      await expect(browser.executeScript(() => window.domChangeEvents.length)).toEqual(0)
       // Add children
       await browser.executeScript(() => {
         document.getElementById('scroller').insertAdjacentHTML('beforeend', `
@@ -160,11 +150,11 @@ describe('core-scroll', () => {
       })
 
       // Assert event dispatched for adding children
-      await expect(browser.executeScript(() => window.domChangeEvents.length)).toEqual(1)
+      await expect(browser.executeScript(() => window.scrollEvents.length)).toEqual(2)
 
       // Assert event dispatched for removing children
       await browser.executeScript(() => document.getElementById('scroller').children[0].remove())
-      await expect(browser.executeScript(() => window.domChangeEvents.length)).toEqual(2)
+      await expect(browser.executeScript(() => window.scrollEvents.length)).toEqual(3)
     })
   })
 

--- a/packages/core-scroll/core-scroll.test.js
+++ b/packages/core-scroll/core-scroll.test.js
@@ -131,6 +131,31 @@ describe('core-scroll', () => {
       })
       await expect(browser.executeScript(() => document.getElementById('scroller').friction)).toEqual(0.1)
     })
+
+    it('dispatches "scroll.change" onConnected and when children are added/removed', async () => {
+      await browser.executeScript(() => {
+        window.scrollEvents = []
+        document.body.innerHTML = '<core-scroll id="scroller"></core-scroll>'
+        document.addEventListener('scroll.change', (event) => (window.scrollEvents.push(event)))
+      })
+      // Assert single event dispatched onConnected
+      await expect(browser.executeScript(() => window.scrollEvents.length)).toEqual(1)
+      // Add children
+      await browser.executeScript(() => {
+        document.getElementById('scroller').insertAdjacentHTML('beforeend', `
+          <div>This is overflowing content</div>
+          <div>This is overflowing content</div>
+          <div>This is overflowing content</div>
+        `)
+      })
+
+      // Assert event dispatched for adding children
+      await expect(browser.executeScript(() => window.scrollEvents.length)).toEqual(2)
+
+      // Assert event dispatched for removing children
+      await browser.executeScript(() => document.getElementById('scroller').children[0].remove())
+      await expect(browser.executeScript(() => window.scrollEvents.length)).toEqual(3)
+    })
   })
 
   describe('scroll-function', () => {

--- a/packages/core-scroll/readme.md
+++ b/packages/core-scroll/readme.md
@@ -75,7 +75,7 @@ demo-->
 ```html
 <!--demo-->
 <div id="jsx-scroll"></div>
-<script type="text/jsx">
+<script type="text/JavaScript">
   class MyScroll extends React.Component {
     constructor (props) {
       super(props)
@@ -112,7 +112,7 @@ demo-->
 
 `core-scroll` calculates scroll distance based on currently visible direct children. When using substructures like `<ul><li>...` you, must tell `core-scroll` what elements are considered items, by using the `items` attribute/property:
 
-```
+```html
 <core-scroll items="li">
   <ul>
     <li>List-item 1</li>
@@ -135,6 +135,50 @@ demo-->
     </ul>
   </core-scroll>
 </div>
+```
+
+### Example: changes in DOM
+
+Core scroll uses a [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) to monitor changes to childnodes.
+Connected buttons are updated (disabled or not) if their viability changes as a result of the DOM-change
+
+
+```html
+<!--demo-->
+<div id="jsx-dynamic-content"></div>
+<script type="text/JavaScript">
+  const Dynamic = () => {
+      const [DOMChanges, setDOMChanges] = React.useState(0)
+      const [elements, setElements] = React.useState([...Array(10).keys()])
+      const content = elements.map(item => <div> Element {item + 1}</div>);
+
+      const handleDOMChange = ({detail: {addedNodes, removedNodes}}) => (setDOMChanges(DOMChanges + addedNodes.length + removedNodes.length))
+      return (
+        <>
+          Children have been updated {DOMChanges} times
+          <br />
+          <button type="button" onClick={() => setElements([...elements, elements.length])}>
+            Add extra child
+          </button>
+          <button type="button" onClick={() => setElements([...Array(10).keys()])}>
+            Set to ten children
+          </button>
+          <button type="button" onClick={() => setElements([])}>
+            Remove all children
+          </button>
+          <br />
+          <button type="button" data-for="scroll-dynamic-content" value="left" aria-label="Rull til venstre">&larr;</button>
+          <button type="button" data-for="scroll-dynamic-content" value="right" aria-label="Rull til høyre">&rarr;</button>
+          <div className="my-wrap">
+            <CoreScroll id="scroll-dynamic-content" className="my-scroll" onScrollDOMChange={handleDOMChange}>
+              {content}
+            </CoreScroll>
+          </div>
+        </>
+      )
+    }
+  ReactDOM.render(<Dynamic />, document.getElementById('jsx-dynamic-content'))
+</script>
 ```
 
 ## Installation
@@ -202,11 +246,13 @@ myScroll.scroll(document.getElementById('childId')) // Scroll to child element, 
 ```jsx
 import CoreScroll from '@nrk/core-scroll/jsx'
 
-<CoreScroll friction={Number}         // Optional. Default 0.8. Controls scroll speed
-            ref={(comp) => {}}        // Optional. Get reference to React component
-            forwardRef={(el) => {}}   // Optional. Get reference to underlying DOM custom element
-            onScrollChange={Function} // Optional. Scroll change event handler
-            onScrollClick={Function}> // Optional. Scroll click event handler
+<CoreScroll friction={Number}             // Optional. Default 0.8. Controls scroll speed
+            ref={(comp) => {}}            // Optional. Get reference to React component
+            forwardRef={(el) => {}}       // Optional. Get reference to underlying DOM custom element
+            onScrollChange={Function}     // Optional. Scroll change event handler
+            onScrollClick={Function}      // Optional. Scroll click event handler
+            onScrollDOMChange={Function}  // Optional. Scroll DOM change event handler
+>
   {/* elements */}
 </CoreScroll>
 
@@ -237,6 +283,18 @@ Fired when clicking a button controlling `core-scroll`:
 document.addEventListener('scroll.click', (event) => {
   event.target        // The scroll element
   event.detail.move   // Direction to move (left, right, up, down)
+})
+```
+
+### scroll.DOMChange
+
+Fired when MutationObserver sees a childlist change within the `core-scroll` element:
+
+```js
+document.addEventListener('scroll.click', (event) => {
+  event.target              // The scroll element
+  event.detail.addedNodes   // Nodes added from the MutationRecord
+  event.detail.removedNodes // Nodes removed from the MutationRecord
 })
 ```
 

--- a/packages/core-scroll/readme.md
+++ b/packages/core-scroll/readme.md
@@ -148,15 +148,10 @@ Connected buttons are updated (disabled or not) if their viability changes as a 
 <div id="jsx-dynamic-content"></div>
 <script type="text/JavaScript">
   const Dynamic = () => {
-      const [DOMChanges, setDOMChanges] = React.useState(0)
       const [elements, setElements] = React.useState([...Array(10).keys()])
       const content = elements.map(item => <div> Element {item + 1}</div>);
-
-      const handleDOMChange = ({detail: {addedNodes, removedNodes}}) => (setDOMChanges(DOMChanges + addedNodes.length + removedNodes.length))
       return (
         <>
-          Children have been updated {DOMChanges} times
-          <br />
           <button type="button" onClick={() => setElements([...elements, elements.length])}>
             Add extra child
           </button>
@@ -170,7 +165,7 @@ Connected buttons are updated (disabled or not) if their viability changes as a 
           <button type="button" data-for="scroll-dynamic-content" value="left" aria-label="Rull til venstre">&larr;</button>
           <button type="button" data-for="scroll-dynamic-content" value="right" aria-label="Rull til høyre">&rarr;</button>
           <div className="my-wrap">
-            <CoreScroll id="scroll-dynamic-content" className="my-scroll" onScrollDOMChange={handleDOMChange}>
+            <CoreScroll id="scroll-dynamic-content" className="my-scroll">
               {content}
             </CoreScroll>
           </div>
@@ -251,7 +246,6 @@ import CoreScroll from '@nrk/core-scroll/jsx'
             forwardRef={(el) => {}}       // Optional. Get reference to underlying DOM custom element
             onScrollChange={Function}     // Optional. Scroll change event handler
             onScrollClick={Function}      // Optional. Scroll click event handler
-            onScrollDOMChange={Function}  // Optional. Scroll DOM change event handler
 >
   {/* elements */}
 </CoreScroll>
@@ -283,18 +277,6 @@ Fired when clicking a button controlling `core-scroll`:
 document.addEventListener('scroll.click', (event) => {
   event.target        // The scroll element
   event.detail.move   // Direction to move (left, right, up, down)
-})
-```
-
-### scroll.DOMChange
-
-Fired when MutationObserver sees a childlist change within the `core-scroll` element:
-
-```js
-document.addEventListener('scroll.click', (event) => {
-  event.target              // The scroll element
-  event.detail.addedNodes   // Nodes added from the MutationRecord
-  event.detail.removedNodes // Nodes removed from the MutationRecord
 })
 ```
 


### PR DESCRIPTION
> whoever is working on core-components right now - THANKS, it is such a great bundle of things ❤️ 

Adding children to a `<CoreScroll>` after the component has rendered (because `async`) does not trigger the `scroll.change` event and subsequently (for `jsx` anyway) does not set the correct state for the scroll buttons (given the example implementation seen below).

Currently `scroll.change` is triggered on first render, when both `scrollLeft` and `scrollLeft` is 0 resulting in not displaying any scroll-buttons if the child list is empty. This PR adds a mutation observer that trigger `this.handleEvent` so that buttons can be re-initialised.

Another solution is of course to solve this from the outside using a `ref`. I do feel like this behavior (dispatching `scroll.change`) when children change is a better solution since it solves all use cases where children can be dynamically added or removed.

I'm happy to update the PR with all or any requested changes 🙌 

```js
class MyScroll extends React.Component {
    constructor (props) {
      super(props)
      this.state = { children: null }
      this.onScroll = this.onScroll.bind(this)
      setTimeout(() => {
        // Children set async -> state of disabled buttons are wrong (not updated)
        this.setState(s => ({...s, children: (
          <>
            <div>1</div><div>2</div><div>3</div><div>4</div><a href="#">5</a>
            <div>6</div><div>7</div><div>8</div><div>9</div><div>10</div>
            <div>11</div><div>12</div><div>13</div><div>14</div><div>15</div>
          </>
        )}))
      }, 500);
    }
    onScroll ({target}) {
      console.log('ON SCROLL');
      this.setState(s => ({
        ...s,
        left: target.scrollLeft ? () => target.scroll('left') : null,
        right: target.scrollRight ? () => target.scroll('right') : null
      }))
    }
    render () {
      return <div>
        <button disabled={!this.state.left} onClick={this.state.left}>Left JSX</button>
        <button disabled={!this.state.right} onClick={this.state.right}>Right JSX</button>
        <div className="my-wrap">
          <CoreScroll className="my-scroll" onScrollChange={this.onScroll}>
            {this.state.children}
          </CoreScroll>
        </div>
      </div>
    }
  }
  ReactDOM.render(<MyScroll />, document.getElementById('jsx-scroll'))
```