### PR TITLE
Core scroll readme update

### DIFF
--- a/packages/core-scroll/readme.md
+++ b/packages/core-scroll/readme.md
@@ -3,7 +3,6 @@
 > `@nrk/core-scroll` enhances any tag with content to be scrollable with mouse interaction on non-touch-devices.
 > It also hides the scrollbars and automatically disables animation for users who prefers [reduced motion](https://css-tricks.com/introduction-reduced-motion-media-query/).
 
-
 <!-- <script src="https://unpkg.com/preact"></script>
 <script src="https://unpkg.com/preact-compat"></script>
 <script>
@@ -142,7 +141,6 @@ demo-->
 Core scroll uses a [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) to monitor changes to childnodes.
 Connected buttons are updated (disabled or not) if their viability changes as a result of the DOM-change
 
-
 ```html
 <!--demo-->
 <div id="jsx-dynamic-content"></div>
@@ -261,18 +259,15 @@ _Note: Starting a `core-scroll` mousemove inside a iframe, and releasing the mou
 
 Fired regularly during a scroll. The event is [throttled](https://css-tricks.com/the-difference-between-throttling-and-debouncing/) to run every 500ms and ensure better performance:
 
-
 ```js
 document.addEventListener('scroll.change', (event) => {
   event.target   // The scroll element
 })
 ```
 
-
 ### scroll.click
 
 Fired when clicking a button controlling `core-scroll`:
-
 
 ```js
 document.addEventListener('scroll.click', (event) => {
@@ -295,8 +290,6 @@ document.addEventListener('scroll', (event) => {
   }
 }, true) // Note the true parameter, activating capture listening
 ```
-
-
 
 ## Styling
 
@@ -330,4 +323,5 @@ The `<button>` elements receive `disabled` attributes reflecting the current scr
 If you are creating a horizontal layout, you might experience unwanted vertical scrolling in Safari. This happens when children of <code>@nrk/core-scroll</code> have half-pixel height values (due to images/videos/elements with aspect-ratio sizing). Avoid the vertical scrolling by setting  <code>padding-bottom: 1px</code> on the <code>@nrk/core-scroll</code> element.
 
 ### NB: iOS 12.2+ bug
+
 `core-scroll` automatically adds `-webkit-overflow-scrolling: touch` as this is required by iOS to enable momentum scrolling. An unfortunate side effect (introduced in iOS 12.2) is that the scrollable area is rendered on the GPU, which breaks `position: fixed` on child elements. Please place elements with `position: fixed` (i.e. a `<core-dialog>`) outside the markup of `<core-scroll>`.

--- a/packages/core-scroll/readme.md
+++ b/packages/core-scroll/readme.md
@@ -193,10 +193,11 @@ Using static registers the custom element with default name automatically:
 
 Remember to [polyfill](https://github.com/webcomponents/polyfills/tree/master/packages/custom-elements) custom elements if needed.
 
-
 ## Usage
 
-Buttons can control a `core-scroll` by targeting its ID and specifying a direction. The `disabled` attribute is automatically added/removed to controller buttons when there is no more pixels to scroll in specified direction. Important: `core-scroll` manipulates styling to hide scrollbars, [see how to work with margin and height &rarr;](#styling)
+Buttons should be connected to a `core-scroll` element to control scrolling for keyboard-users. Just add the `data-for` attribute with the id of `core-scroll` and assign a directional value. The `disabled` attribute is then automatically toggled when there is or isn't space to scroll in the assigned direction.
+
+_Note: `core-scroll` adds styling to hide scrollbars, [see how to work with margin and height &rarr;](#styling)._
 
 ```html
 <button

--- a/packages/core-scroll/readme.md
+++ b/packages/core-scroll/readme.md
@@ -255,7 +255,7 @@ import CoreScroll from '@nrk/core-scroll/jsx'
 
 ## Events
 
-*Note: Starting a `core-scroll` mousemove inside a iframe, and releasing the mouse outside, will fail to end movement. This is due to `mouseup` not bubbling though iframes. Please avoid iframes.*
+_Note: Starting a `core-scroll` mousemove inside a iframe, and releasing the mouse outside, will result in an incomplete action and fail to end movement. This is due to `mouseup` not bubbling though iframes. Please avoid iframes._
 
 ### scroll.change
 


### PR DESCRIPTION
Resolves #666 🤘 

Incorporated text changes for usage and event -sections.
Also removed some surplus white-space through formatting the file, leaving the examples alone. 

I omitted the infinite scrolling part as I was unable to reproduce this in testing. The action is suspended inside the iframe until you move the cursor back into the iframe upon which the scrolling action will resume as though a mouseup-action never happened (which to the core-scroll element inside the iframe remains true)
