### PR TITLE
fix(core-suggest): adjust filter case to allow to filter for empty string

### DIFF
--- a/packages/core-suggest/core-suggest.js
+++ b/packages/core-suggest/core-suggest.js
@@ -296,7 +296,7 @@ function onInput (self, event) {
  * @fires `suggest.filter`
  */
 function filterItemsByInput (self) {
-  if (!dispatchEvent(self, 'suggest.filter') || !(self.input && self.input.value)) return
+  if (!dispatchEvent(self, 'suggest.filter') || !(self.input && self.input.value != null)) return
   const value = self.input.value.toLowerCase()
   const items = self.querySelectorAll('a,button')
 

--- a/packages/core-suggest/core-suggest.spec.ts
+++ b/packages/core-suggest/core-suggest.spec.ts
@@ -95,6 +95,18 @@ test.describe('core-suggest', () => {
     await expect(coreSuggest.getByText('Suggest 1')).toBeHidden()
     await expect(coreSuggest.getByText('Suggest 2')).toBeVisible()
     await expect(coreSuggest.getByText('Suggest 3')).toBeHidden()
+    await expect(coreSuggest.getByText('Suggest 4')).toBeHidden()
+  })
+
+  test('filter is reset on clearing input value', async ({ page }) => {
+    await defaultTemplate(page)
+    await coreSuggestInput.fill('2')
+    await expect(coreSuggest.getByText('Suggest 1')).toBeHidden()
+    await coreSuggestInput.clear()
+    await expect(coreSuggest.getByText('Suggest 1')).toBeVisible()
+    await expect(coreSuggest.getByText('Suggest 2')).toBeVisible()
+    await expect(coreSuggest.getByText('Suggest 3')).toBeVisible()
+    await expect(coreSuggest.getByText('Suggest 4')).toBeVisible()
   })
   
   // TODO: Review assertions


### PR DESCRIPTION
This PR fixes built-in filtering of static content in core-suggest

Previously, when clearing the input to empty value `''`, this would parse as falsy and no reset/re-filtering would take place. By changing the case to `self.input.value != null` we maintian filtering for `null` or `undefined` but allow for filtering using other falsy values like `''`, `0`, `NaN`.

Note that being an input, the value will be cast to a string, and so the effective change will only be to allow for filtering by empty string. e.g. `NaN` would actually be `'NaN'` and as such a perfectly valid string to filter by.

Resolves #748 